### PR TITLE
UINV-138 Common style to align last column to the end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change history for stripes-acq-components
 
 ## (IN PROGRESS)
+### Stories
+* [UINV-138](https://issues.folio.org/browse/UINV-138) Align actions icons in table to right hand side of view pane(s)
 
 ## [2.0.4](https://github.com/folio-org/stripes-acq-components/tree/v2.0.4) (2020-04-09)
 [Full Changelog](https://github.com/folio-org/stripes-acq-components/compare/v2.0.3...v2.0.4)

--- a/lib/utils/acqRowFormatter/acqRowFormatter.css
+++ b/lib/utils/acqRowFormatter/acqRowFormatter.css
@@ -1,0 +1,3 @@
+.alignLastColToEnd > div:last-of-type {
+  margin-left: auto;
+}

--- a/lib/utils/acqRowFormatter/acqRowFormatter.js
+++ b/lib/utils/acqRowFormatter/acqRowFormatter.js
@@ -1,0 +1,38 @@
+/* eslint-disable react/prop-types */
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+import css from './acqRowFormatter.css';
+
+export function acqRowFormatter({ rowIndex, rowClass, cells, rowProps, labelStrings }) {
+  // Default row element
+  let Element = 'div';
+
+  // Render a <Link> if a "to"-prop is provided (react-router API)
+  if (rowProps.to) {
+    Element = Link;
+  }
+
+  // Render an anchor tag if an "href"-prop is provided
+  if (rowProps.href) {
+    Element = 'a';
+  }
+
+  // Render a button if an "onClick"-prop is provided
+  if (rowProps.onClick) {
+    Element = 'button';
+  }
+
+  return (
+    <Element
+      key={`row-${rowIndex}`}
+      className={[rowClass, rowProps.alignLastColToEnd ? css.alignLastColToEnd : null].filter(Boolean).join(' ')}
+      aria-label={labelStrings.join('...')}
+      role="row"
+      {...rowProps}
+      tabIndex="0"
+    >
+      {cells}
+    </Element>
+  );
+}

--- a/lib/utils/acqRowFormatter/acqRowFormatter.js
+++ b/lib/utils/acqRowFormatter/acqRowFormatter.js
@@ -22,14 +22,15 @@ export function acqRowFormatter({ rowIndex, rowClass, cells, rowProps, labelStri
   if (rowProps.onClick) {
     Element = 'button';
   }
+  const { alignLastColToEnd, ...restRowProps } = rowProps;
 
   return (
     <Element
       key={`row-${rowIndex}`}
-      className={[rowClass, rowProps.alignLastColToEnd ? css.alignLastColToEnd : null].filter(Boolean).join(' ')}
+      className={[rowClass, alignLastColToEnd ? css.alignLastColToEnd : null].filter(Boolean).join(' ')}
       aria-label={labelStrings.join('...')}
       role="row"
-      {...rowProps}
+      {...restRowProps}
       tabIndex="0"
     >
       {cells}

--- a/lib/utils/acqRowFormatter/acqRowFormatter.test.js
+++ b/lib/utils/acqRowFormatter/acqRowFormatter.test.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { render, cleanup } from '@testing-library/react';
+
+import { acqRowFormatter } from './acqRowFormatter';
+import css from './acqRowFormatter.css';
+
+const rowIndex = 0;
+const TEST_ID = 'test-row';
+
+const renderFnResult = (alignLastColToEnd) => (render(
+  <>
+    {acqRowFormatter({
+      cells: <div>cells</div>,
+      labelStrings: [],
+      rowProps: {
+        alignLastColToEnd,
+        'data-testid': TEST_ID,
+      },
+      rowIndex,
+    })}
+  </>,
+));
+
+describe('acqRowFormatter', () => {
+  afterEach(cleanup);
+
+  it('should have class to align cells to the end', () => {
+    const { getByTestId } = renderFnResult(true);
+
+    expect(getByTestId(TEST_ID).classList.contains(css.alignLastColToEnd)).toBe(true);
+  });
+
+  it('should not have class to align cells to the end', () => {
+    const { getByTestId } = renderFnResult();
+
+    expect(getByTestId(TEST_ID).classList.contains(css.alignLastColToEnd)).toBe(false);
+  });
+});

--- a/lib/utils/acqRowFormatter/acqRowFormatter.test.js
+++ b/lib/utils/acqRowFormatter/acqRowFormatter.test.js
@@ -7,7 +7,7 @@ import css from './acqRowFormatter.css';
 const rowIndex = 0;
 const TEST_ID = 'test-row';
 
-const renderFnResult = (alignLastColToEnd) => (render(
+const renderFnResult = (alignLastColToEnd, onClick) => (render(
   <>
     {acqRowFormatter({
       cells: <div>cells</div>,
@@ -15,6 +15,7 @@ const renderFnResult = (alignLastColToEnd) => (render(
       rowProps: {
         alignLastColToEnd,
         'data-testid': TEST_ID,
+        onClick,
       },
       rowIndex,
     })}
@@ -25,7 +26,7 @@ describe('acqRowFormatter', () => {
   afterEach(cleanup);
 
   it('should have class to align cells to the end', () => {
-    const { getByTestId } = renderFnResult(true);
+    const { getByTestId } = renderFnResult(true, () => { });
 
     expect(getByTestId(TEST_ID).classList.contains(css.alignLastColToEnd)).toBe(true);
   });

--- a/lib/utils/acqRowFormatter/acqRowFormatter.test.js
+++ b/lib/utils/acqRowFormatter/acqRowFormatter.test.js
@@ -7,15 +7,14 @@ import css from './acqRowFormatter.css';
 const rowIndex = 0;
 const TEST_ID = 'test-row';
 
-const renderFnResult = (alignLastColToEnd, onClick) => (render(
+const renderFnResult = (rowProps) => (render(
   <>
     {acqRowFormatter({
       cells: <div>cells</div>,
       labelStrings: [],
       rowProps: {
-        alignLastColToEnd,
         'data-testid': TEST_ID,
-        onClick,
+        ...rowProps,
       },
       rowIndex,
     })}
@@ -26,14 +25,27 @@ describe('acqRowFormatter', () => {
   afterEach(cleanup);
 
   it('should have class to align cells to the end', () => {
-    const { getByTestId } = renderFnResult(true, () => { });
+    const { getByTestId } = renderFnResult({ alignLastColToEnd: true });
 
+    expect(getByTestId(TEST_ID).tagName).toEqual('DIV');
     expect(getByTestId(TEST_ID).classList.contains(css.alignLastColToEnd)).toBe(true);
   });
 
   it('should not have class to align cells to the end', () => {
-    const { getByTestId } = renderFnResult();
+    const { getByTestId } = renderFnResult({});
 
     expect(getByTestId(TEST_ID).classList.contains(css.alignLastColToEnd)).toBe(false);
+  });
+
+  it('should render a button', () => {
+    const { getByTestId } = renderFnResult({ onClick: () => { } });
+
+    expect(getByTestId(TEST_ID).tagName).toEqual('BUTTON');
+  });
+
+  it('should render an anchor', () => {
+    const { getByTestId } = renderFnResult({ href: '#someLink' });
+
+    expect(getByTestId(TEST_ID).tagName).toEqual('A');
   });
 });

--- a/lib/utils/acqRowFormatter/index.js
+++ b/lib/utils/acqRowFormatter/index.js
@@ -1,0 +1,1 @@
+export * from './acqRowFormatter';

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1,3 +1,4 @@
+export * from './acqRowFormatter';
 export * from './batchFetch';
 export * from './calculateFundAmount';
 export * from './calculateFundDistributionTotal';


### PR DESCRIPTION
`rowProps.alignLastColToEnd` is used as a flag

<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
Align actions icons in table to right hand side of view pane(s)
https://issues.folio.org/browse/UINV-138
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

<!-- OPTIONAL
#### TODOS and Open Questions
 [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
