### PR TITLE
Use 'actsAs' instead of deprecated 'type'

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "redux": "*"
   },
   "stripes": {
-    "type": "",
+    "actsAs": [""],
     "okapiInterfaces": {
       "acquisitions-units": "1.1",
       "configuration": "2.0",


### PR DESCRIPTION
Just cutting down on console spam. There's still no great way of representing this kind of module, but [it's what we've been using](https://github.com/folio-org/stripes-erm-components/blob/271535e5c48fa17cf2b806f91ad7cd8415102d43/package.json#L59) and given that [`type` just gets shoved into an `actsAs` array in current stripes-core](https://github.com/folio-org/stripes-core/blob/65a560093520cb3c0296788f331d426a5a2441e5/webpack/stripes-module-parser.js#L87), they're functionally equivalent.