### PR TITLE
UIORGS-173: Added aria-label for the 'Select all' checkbox in the find record modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Bug fixes
 * [UIOR-523](https://issues.folio.org/browse/UIOR-523) Accessibility Error: Buttons must have discernible text
 * [UIOR-522](https://issues.folio.org/browse/UIOR-522) Accessibility Error: ARIA attributes must conform to valid values
+* [UIORGS-173](https://issues.folio.org/browse/UIORGS-173) Accessibility Error: Added aria-label for "Select all"-checkbox in the find record modal
 
 ## [2.1.2](https://github.com/folio-org/stripes-acq-components/tree/v2.1.2) (2020-06-12)
 [Full Changelog](https://github.com/folio-org/stripes-acq-components/compare/v2.1.1...v2.1.2)

--- a/lib/PluginFindRecord/PluginFindRecordModal.js
+++ b/lib/PluginFindRecord/PluginFindRecordModal.js
@@ -345,12 +345,17 @@ class PluginFindRecordModal extends React.Component {
                         autosize
                         columnMapping={{
                           isChecked: (
-                            <Checkbox
-                              checked={isAllChecked}
-                              data-test-find-records-modal-select-all
-                              onChange={this.toggleAll}
-                              type="checkbox"
-                            />
+                            <FormattedMessage id="stripes-acq-components.modal.selectAll">
+                              {ariaLabel => (
+                                <Checkbox
+                                  aria-label={ariaLabel}
+                                  checked={isAllChecked}
+                                  data-test-find-records-modal-select-all
+                                  onChange={this.toggleAll}
+                                  type="checkbox"
+                                />
+                              )}
+                            </FormattedMessage>
                           ),
                           ...columnMapping,
 

--- a/translations/stripes-acq-components/en.json
+++ b/translations/stripes-acq-components/en.json
@@ -477,6 +477,7 @@
   "fundDistribution.currentEncumbrance": "Current encumbrance",
 
   "modal.resultsHeader": "Search results",
+  "modal.selectAll": "Select all",
   "modal.noSourceYet": "No source yet",
   "modal.totalSelected": "Total selected: {count}",
 


### PR DESCRIPTION
https://issues.folio.org/browse/UIORGS-173

## Purpose
The "Select all"-checkbox in the find record modal does not have a discernable text or a screen reader friendly message which leaves screen reader users in the dark.

## Approach
This small change adds an aria-label attribute for the checkbox which reads "Select all". 

Note: I kept the localized message very generic since this component is used for different purposes.


## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.
