### PR TITLE
UIF-251 Update view pane to display null as hyphen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## (IN PROGRESS)
 
-* Display ACqUnits as NoValue if no units selected. Refs UIORGS-201
+* Add mocks and display `AmountWithCurrencyField` as `NoValue` if no value is provided. Refs UIF-251
+* Display AcqUnits as `NoValue` if no units selected. Refs UIORGS-201
 * Fix `Datepicker` clears value for redux-form. Refs UINV-181
 * Update fund distribution UX. Refs UIF-245
 * Leverage code for client-side sorting, `FrontendSortingMCL`. Refs UINV-178

--- a/lib/AmountWithCurrencyField/AmountWithCurrencyField.js
+++ b/lib/AmountWithCurrencyField/AmountWithCurrencyField.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { NoValue } from '@folio/stripes/components';
 import {
   withStripes,
   stripesShape,
@@ -8,11 +9,11 @@ import {
 
 import { getAmountWithCurrency } from '../utils';
 
-const AmountWithCurrencyField = ({ stripes, currency, amount = 0, showBrackets }) => {
+const AmountWithCurrencyField = ({ stripes, currency, amount, showBrackets }) => {
   const usedCurrency = currency || stripes.currency;
   const usedAmount = showBrackets ? Math.abs(amount) : amount;
 
-  return (
+  return amount == null ? <NoValue /> : (
     <>
       {showBrackets && '('}
       {getAmountWithCurrency(stripes.locale, usedCurrency, usedAmount)}

--- a/test/jest/__mock__/stripesCore.mock.js
+++ b/test/jest/__mock__/stripesCore.mock.js
@@ -1,23 +1,83 @@
 import React from 'react';
 
-jest.mock('@folio/stripes/core', () => ({
-  ...jest.requireActual('@folio/stripes/core'),
-  stripesConnect: Component => ({ mutator, ...rest }) => {
-    const fakeMutator = mutator || Object.keys(Component.manifest).reduce((acc, mutatorName) => {
-      acc[mutatorName] = {
-        GET: jest.fn(),
-        PUT: jest.fn(),
-        POST: jest.fn(),
-        DELETE: jest.fn(),
-        reset: jest.fn(),
-      };
+jest.mock('@folio/stripes/core', () => {
+  const STRIPES = {
+    actionNames: [],
+    clone: () => ({ ...STRIPES }),
+    connect: () => { },
+    config: {},
+    currency: 'USD',
+    hasInterface: () => true,
+    hasPerm: () => true,
+    locale: 'en-US',
+    logger: {
+      log: () => { },
+    },
+    okapi: {
+      tenant: 'diku',
+      url: 'https://folio-testing-okapi.dev.folio.org',
+    },
+    plugins: {},
+    setBindings: () => { },
+    setCurrency: () => { },
+    setLocale: () => { },
+    setSinglePlugin: () => { },
+    setTimezone: () => { },
+    setToken: () => { },
+    store: {
+      getState: () => { },
+      dispatch: () => { },
+      subscribe: () => { },
+      replaceReducer: () => { },
+    },
+    timezone: 'UTC',
+    user: {
+      perms: {},
+      user: {
+        id: 'b1add99d-530b-5912-94f3-4091b4d87e2c',
+        username: 'diku_admin',
+      },
+    },
+    withOkapi: true,
+  };
 
-      return acc;
-    }, {});
+  return {
+    ...jest.requireActual('@folio/stripes/core'),
+    stripesConnect: Component => ({ mutator, resources, stripes, ...rest }) => {
+      const fakeMutator = mutator || Object.keys(Component.manifest).reduce((acc, mutatorName) => {
+        const returnValue = Component.manifest[mutatorName].records ? [] : {};
 
-    return <Component {...rest} mutator={fakeMutator} />;
-  },
+        acc[mutatorName] = {
+          GET: jest.fn().mockReturnValue(Promise.resolve(returnValue)),
+          PUT: jest.fn().mockReturnValue(Promise.resolve()),
+          POST: jest.fn().mockReturnValue(Promise.resolve()),
+          DELETE: jest.fn().mockReturnValue(Promise.resolve()),
+          reset: jest.fn(),
+        };
 
-  // eslint-disable-next-line react/prop-types
-  Pluggable: props => <>{props.children}</>,
-}), { virtual: true });
+        return acc;
+      }, {});
+
+      const fakeResources = resources || Object.keys(Component.manifest).reduce((acc, resourceName) => {
+        acc[resourceName] = {
+          records: [],
+        };
+
+        return acc;
+      }, {});
+
+      const fakeStripes = stripes || STRIPES;
+
+      return <Component {...rest} mutator={fakeMutator} resources={fakeResources} stripes={fakeStripes} />;
+    },
+
+    withStripes: Component => ({ stripes, ...rest }) => {
+      const fakeStripes = stripes || STRIPES;
+
+      return <Component {...rest} stripes={fakeStripes} />;
+    },
+
+    // eslint-disable-next-line react/prop-types
+    Pluggable: props => <>{props.children}</>,
+  };
+}, { virtual: true });


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
Add mocks and display `AmountWithCurrencyField` as `NoValue` if no value is provided
https://issues.folio.org/browse/UIF-251
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

<!-- OPTIONAL
#### TODOS and Open Questions
 [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
