### PR TITLE
UINV-202 fix by UTC datetime value

### DIFF
--- a/lib/AcqList/constants.js
+++ b/lib/AcqList/constants.js
@@ -5,3 +5,4 @@ export const SORTING_PARAMETER = 'sorting';
 export const SORTING_DIRECTION_PARAMETER = 'sortingDirection';
 export const ASC_DIRECTION = 'ascending';
 export const DESC_DIRECTION = 'descending';
+export const DATE_RANGE_FILTER_FORMAT = 'YYYY-MM-DDTHH:mm:ss.SSS';

--- a/lib/AcqList/utils/queryUtils.js
+++ b/lib/AcqList/utils/queryUtils.js
@@ -1,4 +1,5 @@
 import { omit } from 'lodash';
+import moment from 'moment';
 
 import {
   SEARCH_PARAMETER,
@@ -6,12 +7,15 @@ import {
   SORTING_PARAMETER,
   SORTING_DIRECTION_PARAMETER,
   SEARCH_INDEX_PARAMETER,
+  DATE_RANGE_FILTER_FORMAT,
 } from '../constants';
 
 export const buildDateRangeQuery = (filterKey, filterValue) => {
   const [from, to] = filterValue.split(':');
+  const start = moment(from).startOf('day').utc().format(DATE_RANGE_FILTER_FORMAT);
+  const end = moment(to).endOf('day').utc().format(DATE_RANGE_FILTER_FORMAT);
 
-  return `(${filterKey}>="${from}" and ${filterKey}<="${to}")`;
+  return `(${filterKey}>="${start}" and ${filterKey}<="${end}")`;
 };
 
 export const getFilterParams = (queryParams) => omit(

--- a/lib/AcqList/utils/queryUtils.test.js
+++ b/lib/AcqList/utils/queryUtils.test.js
@@ -1,11 +1,17 @@
+import moment from 'moment';
 import * as queryUtils from './queryUtils';
+
+import { DATE_RANGE_FILTER_FORMAT } from '../constants';
 
 describe('queryUtils', () => {
   describe('buildDateRangeQuery', () => {
+    const start = moment('2014-07-14').startOf('day').utc().format(DATE_RANGE_FILTER_FORMAT);
+    const end = moment('20120-07-14').endOf('day').utc().format(DATE_RANGE_FILTER_FORMAT);
+
     it('should return query based on filter key and value', () => {
       expect(
         queryUtils.buildDateRangeQuery('date', '2014-07-14:20120-07-14'),
-      ).toEqual('(date>="2014-07-14" and date<="20120-07-14")');
+      ).toEqual(`(date>="${start}" and date<="${end}")`);
     });
   });
 });


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
user puts desired date in his timezone. for example, _2020-11-04_ in start and end dates. since we store datetimes in utc on back-end we can just convert to utc begin moment of day in _start_ input and final moment of day in _end_ input. So the filter query to back-end will be like `(metadata.createdDate>="2020-11-03T21:00:00.000" and metadata.createdDate<="2020-11-04T20:59:59.999")`
My local timezone is UTC+3
https://issues.folio.org/browse/UINV-202
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

<!-- OPTIONAL
#### TODOS and Open Questions
 [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
