### PR TITLE
Make <Pluggable> in the stripes-core mock a jest.fn

### DIFF
--- a/test/jest/__mock__/stripesCore.mock.js
+++ b/test/jest/__mock__/stripesCore.mock.js
@@ -84,7 +84,7 @@ jest.mock('@folio/stripes/core', () => {
     },
 
     // eslint-disable-next-line react/prop-types
-    Pluggable: props => <>{props.children}</>,
+    Pluggable: jest.fn(props => <>{props.children}</>),
 
     // eslint-disable-next-line react/prop-types
     IfPermission: props => <>{props.children}</>,


### PR DESCRIPTION
This backwards-compatible change means only that test scripts have the option of mocking `<Pluggable>` using code like
```
Pluggable.mockImplementation(props => {
  if (props.type !== 'find-eresource') throw new Error(`mocked Pluggable: unsupported type ${props.type}`);
  props.onEresourceSelected({
    id: '29168',
    name: 'Lost Tales special edition',
  });
  return null;
});
```

Why do I want this when I don't work on acquisition? It's silly that every module that has Jest/RTL tests maintains its own diverging copies of basically the same mocks, so when I started the tests for `ui-plugin-eusage-reports` I decided to avoid perpetuating this duplication. Instead I import what seem to be a mature and general set of mocks -- those of `strips-acq-components`. They give me exactly what I want _except_ the ability to mock `<Pluggable>`. If I can add these nine characters (`jest.fn()`) I can avoid having to maintain a whole new set of mocks.