### PR TITLE
UISACQCOMP-123 Add common util which will provide translations for `ControlledVocab`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## (IN PROGRESS)
 
+* Add common util which will provide translations for `ControlledVocab`. Refs UISACQCOMP-123.
+
 ## [3.3.0](https://github.com/folio-org/stripes-acq-components/tree/v3.3.0) (2022-10-18)
 [Full Changelog](https://github.com/folio-org/stripes-acq-components/compare/v3.2.4...v3.3.0)
 

--- a/lib/utils/getControlledVocabTranslations.js
+++ b/lib/utils/getControlledVocabTranslations.js
@@ -1,0 +1,7 @@
+export const getControlledVocabTranslations = (translationKey) => ({
+  cannotDeleteTermHeader: `${translationKey}.cannotDeleteTermHeader`,
+  cannotDeleteTermMessage: `${translationKey}.cannotDeleteTermMessage`,
+  deleteEntry: `${translationKey}.deleteEntry`,
+  termDeleted: `${translationKey}.termDeleted`,
+  termWillBeDeleted: `${translationKey}.termWillBeDeleted`,
+});

--- a/lib/utils/getControlledVocabTranslations.test.js
+++ b/lib/utils/getControlledVocabTranslations.test.js
@@ -1,0 +1,11 @@
+import { getControlledVocabTranslations } from './getControlledVocabTranslations';
+
+const rootTranslationKey = 'ui-orders.settings.poNumber.prefixes';
+
+describe('getControlledVocabTranslations', () => {
+  it('should return an object with translation keys for <ControlledVocab> based on passed root translation key', () => {
+    const translations = getControlledVocabTranslations(rootTranslationKey);
+
+    Object.values(translations).forEach((translation) => expect(translation.startsWith(rootTranslationKey)));
+  });
+});

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -14,6 +14,7 @@ export * from './getAcqUnitsOptions';
 export * from './getAddresses';
 export * from './getAmountWithCurrency';
 export * from './getConfigSetting';
+export * from './getControlledVocabTranslations';
 export * from './getErrorCodeFromResponse';
 export * from './getFundsForSelect';
 export * from './getLocationOptions';


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://issues.folio.org/browse/UISACQCOMP-123
## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
To provide translations prop for `ControlledVocab` component we should pass an object whose keys are defined. So, to reduce a boilerplate we can use a function, that takes a root translation key as argument and return an object with translation keys as a result.
<!-- OPTIONAL
#### TODOS and Open Questions
 [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
