### PR TITLE
UISACQCOMP-124: Add handlers for search field and reset all button in PluginFindRecordModal component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## (IN PROGRESS)
 
+* Add handlers for search field and reset all button in PluginFindRecordModal component. Refs UISACQCOMP-124.
+
 ## [3.3.0](https://github.com/folio-org/stripes-acq-components/tree/v3.3.0) (2022-10-18)
 [Full Changelog](https://github.com/folio-org/stripes-acq-components/compare/v3.2.4...v3.3.0)
 

--- a/lib/PluginFindRecord/PluginFindRecordModal.js
+++ b/lib/PluginFindRecord/PluginFindRecordModal.js
@@ -162,6 +162,7 @@ class PluginFindRecordModal extends React.Component {
       sortableColumns = visibleColumns,
       getRecordLabel,
       intl,
+      onSearchChange,
     } = this.props;
     const { checkedMap, isAllChecked } = this.state;
 
@@ -302,7 +303,10 @@ class PluginFindRecordModal extends React.Component {
                               data-test-plugin-search-input
                               marginBottom0
                               name="query"
-                              onChange={getSearchHandlers().query}
+                              onChange={(e) => {
+                                onSearchChange(e.target.value);
+                                getSearchHandlers().query(e);
+                              }}
                               onClear={getSearchHandlers().reset}
                               value={searchValue.query}
                             />
@@ -323,7 +327,10 @@ class PluginFindRecordModal extends React.Component {
                               disabled={!(filterChanged || searchChanged)}
                               fullWidth
                               id="clickable-reset-all"
-                              onClick={resetAll}
+                              onClick={() => {
+                                onSearchChange('');
+                                resetAll();
+                              }}
                             >
                               <Icon icon="times-circle-solid">
                                 <FormattedMessage id="stripes-smart-components.resetAll" />
@@ -424,6 +431,7 @@ PluginFindRecordModal.propTypes = {
   validateSelectedRecords: PropTypes.func,
   getRecordLabel: PropTypes.func,
   intl: PropTypes.object.isRequired,
+  onSearchChange: PropTypes.func,
 };
 
 PluginFindRecordModal.defaultProps = {
@@ -435,6 +443,7 @@ PluginFindRecordModal.defaultProps = {
   modalLabel: '',
   onSaveMultiple: noop,
   renderNewBtn: noop,
+  onSearchChange: noop,
   resultsFormatter: {},
 };
 


### PR DESCRIPTION


<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
* To use [react-highlight-words](https://github.com/bvaughn/react-highlight-words) with `ui-find-import-profile` plugin, we need to add handlers when search field is changed and reset all button is clicked.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
* Added prop `onSearchChange` that calls when search field is changed and when `Reset all` button is clicked.

<!-- OPTIONAL
#### TODOS and Open Questions
 [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->
[PR UIPFIMP-52](https://github.com/folio-org/ui-plugin-find-import-profile/pull/129)
[Ticket UISACQCOMP-124](https://issues.folio.org/browse/UISACQCOMP-124)


<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
