### PR TITLE
UISACQCOMP-127 Add common `useFiltersReset` hook to support filter reset based on location state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add common util which will provide translations for `ControlledVocab`. Refs UISACQCOMP-123.
 * Selection dropdown search textbox doesn't allow use of parentheses characters. Refs UISACQCOMP-125.
+* Add common `useFiltersReset` hook to support filter reset based on location state. Refs UISACQCOMP-127.
 
 ## [3.3.1](https://github.com/folio-org/stripes-acq-components/tree/v3.3.1) (2022-11-18)
 [Full Changelog](https://github.com/folio-org/stripes-acq-components/compare/v3.3.0...v3.3.1)

--- a/lib/AcqList/hooks/index.js
+++ b/lib/AcqList/hooks/index.js
@@ -1,4 +1,5 @@
 export { default as useFilters } from './useFilters';
+export { useFiltersReset } from './useFiltersReset';
 export * from './useFiltersToogle';
 export { default as useList } from './useList';
 export { default as useLocationFilters } from './useLocationFilters';

--- a/lib/AcqList/hooks/useFiltersReset/index.js
+++ b/lib/AcqList/hooks/useFiltersReset/index.js
@@ -1,0 +1,1 @@
+export { useFiltersReset } from './useFiltersReset';

--- a/lib/AcqList/hooks/useFiltersReset/useFiltersReset.js
+++ b/lib/AcqList/hooks/useFiltersReset/useFiltersReset.js
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+export const useFiltersReset = (resetFilters) => {
+  const { state } = useLocation();
+  const shouldResetFilters = state?.resetFilters;
+
+  useEffect(() => {
+    if (shouldResetFilters) resetFilters();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [shouldResetFilters]);
+};

--- a/lib/AcqList/hooks/useFiltersReset/useFiltersReset.test.js
+++ b/lib/AcqList/hooks/useFiltersReset/useFiltersReset.test.js
@@ -1,0 +1,41 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { MemoryRouter } from 'react-router';
+
+import { useFiltersReset } from './useFiltersReset';
+
+const resetFiltersMock = jest.fn();
+
+// eslint-disable-next-line react/prop-types
+const getWrapper = ({ resetFilters = false } = {}) => ({ children }) => (
+  <MemoryRouter
+    initialEntries={[{
+      state: { resetFilters },
+    }]}
+  >
+    {children}
+  </MemoryRouter>
+);
+
+describe('useFiltersReset', () => {
+  beforeEach(() => {
+    resetFiltersMock.mockClear();
+  });
+
+  it('should reset filters if location state contains \'resetFilters\' property equals \'true\'', () => {
+    renderHook(
+      () => useFiltersReset(resetFiltersMock),
+      { wrapper: getWrapper({ resetFilters: true }) },
+    );
+
+    expect(resetFiltersMock).toHaveBeenCalled();
+  });
+
+  it('should not reset filters if location state does not contain \'resetFilters\' property equals \'true\'', () => {
+    renderHook(
+      () => useFiltersReset(resetFiltersMock),
+      { wrapper: getWrapper() },
+    );
+
+    expect(resetFiltersMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://issues.folio.org/browse/UISACQCOMP-127
## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

<!-- OPTIONAL
#### TODOS and Open Questions
 [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
