### PR TITLE
UISACQCOMP-132 Highlight changed values in MCLs for version view

### DIFF
--- a/lib/ContributorDetails/ContributorDetails.js
+++ b/lib/ContributorDetails/ContributorDetails.js
@@ -8,18 +8,39 @@ import {
 
 import { MultiColumnList } from '@folio/stripes/components';
 
-const columnMapping = {
-  contributor: <FormattedMessage id="stripes-acq-components.label.contributor" />,
-  contributorType: <FormattedMessage id="stripes-acq-components.label.contributorType" />,
+import { useVersionWrappedFormatter } from '../VersionHistory/hooks';
+
+const CONTRIBUTOR_COLUMNS = {
+  contributor: 'contributor',
+  contributorType: 'contributorType',
 };
-const visibleColumns = ['contributor', 'contributorType'];
+
+const fieldsMapping = {
+  [CONTRIBUTOR_COLUMNS.contributor]: 'contributor',
+  [CONTRIBUTOR_COLUMNS.contributorType]: 'contributorNameTypeId',
+};
+
+const columnMapping = {
+  [CONTRIBUTOR_COLUMNS.contributor]: <FormattedMessage id="stripes-acq-components.label.contributor" />,
+  [CONTRIBUTOR_COLUMNS.contributorType]: <FormattedMessage id="stripes-acq-components.label.contributorType" />,
+};
+const visibleColumns = [
+  CONTRIBUTOR_COLUMNS.contributor,
+  CONTRIBUTOR_COLUMNS.contributorType,
+];
 
 const ContributorDetails = ({
   contributors,
   contributorNameTypes,
   mclProps,
+  name,
 }) => {
-  const formatter = { contributorType: ({ contributorNameTypeId: id }) => get(find(contributorNameTypes, { id }), 'name', '') };
+  const baseFormatter = {
+    [CONTRIBUTOR_COLUMNS.contributor]: ({ contributor }) => contributor,
+    [CONTRIBUTOR_COLUMNS.contributorType]: ({ contributorNameTypeId: id }) => get(find(contributorNameTypes, { id }), 'name', ''),
+  };
+
+  const formatter = useVersionWrappedFormatter({ baseFormatter, name, fieldsMapping });
 
   return (
     <MultiColumnList
@@ -38,6 +59,7 @@ ContributorDetails.propTypes = {
   contributors: PropTypes.arrayOf(PropTypes.object),
   contributorNameTypes: PropTypes.arrayOf(PropTypes.object),
   mclProps: PropTypes.object,
+  name: PropTypes.string,
 };
 
 ContributorDetails.defaultProps = {

--- a/lib/ContributorDetails/ContributorDetailsContainer.js
+++ b/lib/ContributorDetails/ContributorDetailsContainer.js
@@ -8,7 +8,12 @@ import { DICT_CONTRIBUTOR_NAME_TYPES } from '../constants';
 import { contributorNameTypesManifest } from '../manifests';
 import ContributorDetails from './ContributorDetails';
 
-const ContributorDetailsContainer = ({ resources, contributors, mclProps }) => {
+const ContributorDetailsContainer = ({
+  resources,
+  contributors,
+  mclProps,
+  name,
+}) => {
   const contributorNameTypes = get(resources, [DICT_CONTRIBUTOR_NAME_TYPES, 'records'], []);
 
   return (
@@ -16,6 +21,7 @@ const ContributorDetailsContainer = ({ resources, contributors, mclProps }) => {
       contributorNameTypes={contributorNameTypes}
       contributors={contributors}
       mclProps={mclProps}
+      name={name}
     />
   );
 };
@@ -28,6 +34,7 @@ ContributorDetailsContainer.propTypes = {
   resources: PropTypes.object.isRequired,
   contributors: PropTypes.arrayOf(PropTypes.object),
   mclProps: PropTypes.object,
+  name: PropTypes.string,
 };
 
 ContributorDetailsContainer.defaultProps = {

--- a/lib/ExchangeRateValue/ExchangeRateValue.js
+++ b/lib/ExchangeRateValue/ExchangeRateValue.js
@@ -10,25 +10,34 @@ import {
 import { useExchangeRateValue } from './useExchangeRateValue';
 
 const ExchangeRateValue = ({
+  component,
   exchangeFrom,
   exchangeTo,
   manualExchangeRate,
   labelId,
+  name,
 }) => {
   const { isLoading, exchangeRate } = useExchangeRateValue(exchangeFrom, exchangeTo, manualExchangeRate);
 
+  const Component = component || KeyValue;
+
   return (
-    <KeyValue label={<FormattedMessage id={labelId} />}>
+    <Component
+      label={<FormattedMessage id={labelId} />}
+      name={name}
+    >
       {isLoading ? <Loading /> : exchangeRate}
-    </KeyValue>
+    </Component>
   );
 };
 
 ExchangeRateValue.propTypes = {
+  component: PropTypes.node,
   exchangeFrom: PropTypes.string,
   exchangeTo: PropTypes.string.isRequired,
   manualExchangeRate: PropTypes.number,
   labelId: PropTypes.string,
+  name: PropTypes.string,
 };
 
 ExchangeRateValue.defaultProps = {

--- a/lib/FundDistribution/FundDistributionView/FundDistributionView.js
+++ b/lib/FundDistribution/FundDistributionView/FundDistributionView.js
@@ -14,9 +14,11 @@ import {
 import { AmountWithCurrencyField } from '../../AmountWithCurrencyField';
 import { FUND_DISTR_TYPE } from '../../constants';
 import { fundDistributionShape } from '../../shapes';
+import { useVersionWrappedFormatter } from '../../VersionHistory';
 import {
   FUND_DISTRIBUTION_COLUMNS,
   FUND_DISTRIBUTION_COLUMN_MAPPING,
+  FUND_DISTRIBUTION_FIELDS_MAPPINGS,
   FUND_DISTRIBUTION_VISIBLE_COLUMNS,
 } from './constants';
 
@@ -71,15 +73,22 @@ const FundDistributionView = ({
   currency,
   expenseClasses,
   mclProps = {},
+  name,
 }) => {
   const visibleColumns = get(fundsToDisplay, '0.adjustmentDescription')
     ? ['adjustmentDescription', ...FUND_DISTRIBUTION_VISIBLE_COLUMNS]
     : FUND_DISTRIBUTION_VISIBLE_COLUMNS;
 
-  const resultFormatter = useMemo(
+  const baseFormatter = useMemo(
     () => getFundDistributionResultFormatter(currency, expenseClasses, amounts),
     [currency, expenseClasses, amounts],
   );
+
+  const formatter = useVersionWrappedFormatter({
+    baseFormatter,
+    name,
+    fieldsMapping: FUND_DISTRIBUTION_FIELDS_MAPPINGS,
+  });
 
   return (
     <Row>
@@ -88,7 +97,7 @@ const FundDistributionView = ({
           contentData={fundsToDisplay}
           visibleColumns={visibleColumns}
           columnMapping={FUND_DISTRIBUTION_COLUMN_MAPPING}
-          formatter={resultFormatter}
+          formatter={formatter}
           interactive={false}
           {...mclProps}
         />
@@ -103,6 +112,7 @@ FundDistributionView.propTypes = {
   currency: PropTypes.string.isRequired,
   expenseClasses: PropTypes.arrayOf(PropTypes.object).isRequired,
   mclProps: PropTypes.object,
+  name: PropTypes.string,
 };
 
 export default FundDistributionView;

--- a/lib/FundDistribution/FundDistributionView/FundDistributionViewContainer.js
+++ b/lib/FundDistribution/FundDistributionView/FundDistributionViewContainer.js
@@ -36,6 +36,7 @@ const FundDistributionViewContainer = ({
   resources,
   groupBy,
   mclProps,
+  name: nameProp,
 }) => {
   const ky = useOkapiKy();
   const [isLoading, setIsLoading] = useState(true);
@@ -112,6 +113,7 @@ const FundDistributionViewContainer = ({
       totalAmount={totalAmount}
       currency={currency}
       mclProps={mclProps}
+      name={nameProp}
     />
   );
 };
@@ -128,6 +130,7 @@ FundDistributionViewContainer.manifest = Object.freeze({
 FundDistributionViewContainer.propTypes = {
   mclProps: PropTypes.object,
   mutator: PropTypes.object.isRequired,
+  name: PropTypes.string,
   fundDistributions: fundDistributionShape,
   totalAmount: PropTypes.number,
   currency: PropTypes.string,

--- a/lib/FundDistribution/FundDistributionView/constants.js
+++ b/lib/FundDistribution/FundDistributionView/constants.js
@@ -19,6 +19,12 @@ export const FUND_DISTRIBUTION_VISIBLE_COLUMNS = [
   FUND_DISTRIBUTION_COLUMNS.currentEncumbrance,
 ];
 
+export const FUND_DISTRIBUTION_FIELDS_MAPPINGS = {
+  [FUND_DISTRIBUTION_COLUMNS.name]: 'code',
+  [FUND_DISTRIBUTION_COLUMNS.value]: 'value',
+  [FUND_DISTRIBUTION_COLUMNS.expenseClass]: 'expenseClassId',
+};
+
 export const FUND_DISTRIBUTION_COLUMN_MAPPING = {
   [FUND_DISTRIBUTION_COLUMNS.adjustmentDescription]: <FormattedMessage id="stripes-acq-components.fundDistribution.adjustmentDescription" />,
   [FUND_DISTRIBUTION_COLUMNS.name]: <FormattedMessage id="stripes-acq-components.fundDistribution.name" />,

--- a/lib/ProductIdDetails/ProductIdDetails.js
+++ b/lib/ProductIdDetails/ProductIdDetails.js
@@ -8,19 +8,40 @@ import {
 
 import { MultiColumnList } from '@folio/stripes/components';
 
-const columnMapping = {
-  productId: <FormattedMessage id="stripes-acq-components.label.productId" />,
-  qualifier: <FormattedMessage id="stripes-acq-components.label.qualifier" />,
-  productIdType: <FormattedMessage id="stripes-acq-components.label.productIdType" />,
+import { useVersionWrappedFormatter } from '../VersionHistory';
+
+const PRODUCT_ID_COLUMNS = {
+  productId: 'productId',
+  qualifier: 'qualifier',
+  productIdType: 'productIdType',
 };
-const visibleColumns = ['productId', 'qualifier', 'productIdType'];
+
+const fieldsMapping = { ...PRODUCT_ID_COLUMNS };
+
+const columnMapping = {
+  [PRODUCT_ID_COLUMNS.productId]: <FormattedMessage id="stripes-acq-components.label.productId" />,
+  [PRODUCT_ID_COLUMNS.qualifier]: <FormattedMessage id="stripes-acq-components.label.qualifier" />,
+  [PRODUCT_ID_COLUMNS.productIdType]: <FormattedMessage id="stripes-acq-components.label.productIdType" />,
+};
+const visibleColumns = [
+  PRODUCT_ID_COLUMNS.productId,
+  PRODUCT_ID_COLUMNS.qualifier,
+  PRODUCT_ID_COLUMNS.productIdType,
+];
 
 const ProductIdDetails = ({
   productIds,
   identifierTypes,
   mclProps,
+  name,
 }) => {
-  const formatter = { productIdType: ({ productIdType }) => get(find(identifierTypes, { id: productIdType }), 'name', '') };
+  const baseFormatter = {
+    [PRODUCT_ID_COLUMNS.productId]: ({ productId }) => productId,
+    [PRODUCT_ID_COLUMNS.qualifier]: ({ qualifier }) => qualifier,
+    [PRODUCT_ID_COLUMNS.productIdType]: ({ productIdType }) => get(find(identifierTypes, { id: productIdType }), 'name', ''),
+  };
+
+  const formatter = useVersionWrappedFormatter({ baseFormatter, name, fieldsMapping });
 
   return (
     <MultiColumnList
@@ -39,6 +60,7 @@ ProductIdDetails.propTypes = {
   identifierTypes: PropTypes.arrayOf(PropTypes.object),
   productIds: PropTypes.arrayOf(PropTypes.object),
   mclProps: PropTypes.object,
+  name: PropTypes.string,
 };
 
 ProductIdDetails.defaultProps = {

--- a/lib/ProductIdDetails/ProductIdDetailsContainer.js
+++ b/lib/ProductIdDetails/ProductIdDetailsContainer.js
@@ -8,7 +8,12 @@ import { DICT_IDENTIFIER_TYPES } from '../constants';
 import { identifierTypesManifest } from '../manifests';
 import ProductIdDetails from './ProductIdDetails';
 
-const ProductIdDetailsContainer = ({ resources, productIds, mclProps }) => {
+const ProductIdDetailsContainer = ({
+  resources,
+  productIds,
+  mclProps,
+  name,
+}) => {
   const identifierTypes = get(resources, [DICT_IDENTIFIER_TYPES, 'records'], []);
 
   return (
@@ -16,6 +21,7 @@ const ProductIdDetailsContainer = ({ resources, productIds, mclProps }) => {
       identifierTypes={identifierTypes}
       productIds={productIds}
       mclProps={mclProps}
+      name={name}
     />
   );
 };
@@ -28,6 +34,7 @@ ProductIdDetailsContainer.propTypes = {
   resources: PropTypes.object.isRequired,
   productIds: PropTypes.arrayOf(PropTypes.object),
   mclProps: PropTypes.object,
+  name: PropTypes.string,
 };
 
 ProductIdDetailsContainer.defaultProps = {

--- a/lib/VendorReferenceNumbers/VendorReferenceNumbersDetails/VendorReferenceNumbersDetails.js
+++ b/lib/VendorReferenceNumbers/VendorReferenceNumbersDetails/VendorReferenceNumbersDetails.js
@@ -6,22 +6,38 @@ import { find } from 'lodash';
 import { MultiColumnList } from '@folio/stripes/components';
 
 import { REF_NUMBER_TYPE_OPTIONS } from '../../constants';
+import { useVersionWrappedFormatter } from '../../VersionHistory';
+
+const VENDOR_REF_NUMBER_COLUMNS = {
+  refNumber: 'refNumber',
+  refNumberType: 'refNumberType',
+};
+
+const fieldsMapping = { ...VENDOR_REF_NUMBER_COLUMNS };
 
 const columnMapping = {
-  refNumber: <FormattedMessage id="stripes-acq-components.referenceNumbers.refNumber" />,
-  refNumberType: <FormattedMessage id="stripes-acq-components.referenceNumbers.refNumberType" />,
+  [VENDOR_REF_NUMBER_COLUMNS.refNumber]: <FormattedMessage id="stripes-acq-components.referenceNumbers.refNumber" />,
+  [VENDOR_REF_NUMBER_COLUMNS.refNumberType]: <FormattedMessage id="stripes-acq-components.referenceNumbers.refNumberType" />,
 };
-const visibleColumns = ['refNumber', 'refNumberType'];
-const formatter = {
+
+const visibleColumns = [
+  VENDOR_REF_NUMBER_COLUMNS.refNumber,
+  VENDOR_REF_NUMBER_COLUMNS.refNumberType,
+];
+
+const baseFormatter = {
+  [VENDOR_REF_NUMBER_COLUMNS.refNumber]: ({ refNumber }) => refNumber,
   // eslint-disable-next-line react/prop-types
-  refNumberType: ({ refNumberType: value }) => {
+  [VENDOR_REF_NUMBER_COLUMNS.refNumberType]: ({ refNumberType: value }) => {
     const labelId = find(REF_NUMBER_TYPE_OPTIONS, { value })?.labelId;
 
     return labelId ? <FormattedMessage id={labelId} /> : value;
   },
 };
 
-const VendorReferenceNumbersDetails = ({ referenceNumbers, mclProps }) => {
+const VendorReferenceNumbersDetails = ({ referenceNumbers, mclProps, name }) => {
+  const formatter = useVersionWrappedFormatter({ baseFormatter, name, fieldsMapping });
+
   return (
     <MultiColumnList
       columnMapping={columnMapping}
@@ -37,6 +53,7 @@ const VendorReferenceNumbersDetails = ({ referenceNumbers, mclProps }) => {
 
 VendorReferenceNumbersDetails.propTypes = {
   mclProps: PropTypes.object,
+  name: PropTypes.string,
   referenceNumbers: PropTypes.arrayOf(PropTypes.object),
 };
 

--- a/lib/VersionHistory/VersionHistoryPane/VersionHistoryPane.js
+++ b/lib/VersionHistory/VersionHistoryPane/VersionHistoryPane.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import { keyBy, uniq } from 'lodash';
-import { memo, useMemo } from 'react';
+import { memo, useContext, useMemo } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { Link } from 'react-router-dom';
 
@@ -15,8 +15,8 @@ import {
   useUsersBatch,
 } from '../../hooks';
 import { getFieldLabels } from '../getFieldLabels';
-import { useVersionsDifference } from '../hooks';
 import { VersionCard } from '../VersionCard';
+import { VersionViewContext } from '../VersionViewContext';
 
 const paneTitle = <FormattedMessage id="stripes-acq-components.versionHistory.pane.header" />;
 
@@ -27,14 +27,15 @@ const VersionHistoryPane = ({
   onClose,
   onSelectVersion,
   labelsMap,
-  snapshotPath,
   versions,
 }) => {
   const intl = useIntl();
   const { paneTitleRef } = usePaneFocus();
+  const versionContext = useContext(VersionViewContext);
 
-  const { versionsMap, users: versionUsers } = useVersionsDifference(versions, snapshotPath);
-  const userIds = useMemo(() => uniq(versionUsers.map(({ id: userId }) => userId)), [versionUsers]);
+  const userIds = useMemo(() => (
+    uniq(versionContext?.versionsUsers?.map(({ id: userId }) => userId))
+  ), [versionContext?.versionsUsers]);
 
   const { users, isLoading } = useUsersBatch(userIds);
   const usersMap = useMemo(() => keyBy(users, 'id'), [users]);
@@ -48,7 +49,7 @@ const VersionHistoryPane = ({
       userId,
     }, i) => {
       const user = usersMap[userId];
-      const changedFields = getFieldLabels(intl, versionsMap[versionId]?.paths, labelsMap);
+      const changedFields = getFieldLabels(intl, versionContext?.versionsMap?.[versionId]?.paths, labelsMap);
 
       const source = (
         <FormattedMessage
@@ -81,8 +82,8 @@ const VersionHistoryPane = ({
     labelsMap,
     onSelectVersion,
     usersMap,
+    versionContext?.versionsMap,
     versions,
-    versionsMap,
   ]);
 
   if (isLoading || isLoadingProp) {
@@ -123,7 +124,6 @@ VersionHistoryPane.propTypes = {
   onClose: PropTypes.func.isRequired,
   onSelectVersion: PropTypes.func.isRequired,
   labelsMap: PropTypes.object.isRequired,
-  snapshotPath: PropTypes.string.isRequired,
   versions: PropTypes.arrayOf(PropTypes.object).isRequired,
 };
 

--- a/lib/VersionHistory/VersionHistoryPane/VersionHistoryPane.test.js
+++ b/lib/VersionHistory/VersionHistoryPane/VersionHistoryPane.test.js
@@ -4,6 +4,7 @@ import { cloneDeep, set } from 'lodash';
 
 import { orderLineAuditEvent } from '../../../test/jest/fixtures';
 import { useUsersBatch } from '../../hooks';
+import { VersionViewContextProvider } from '../VersionViewContext';
 import VersionHistoryPane from './VersionHistoryPane';
 
 jest.mock('../../hooks', () => ({
@@ -27,18 +28,28 @@ const poLineLabelsMap = {
 const defaultProps = {
   currentVersion: TEST_ID,
   labelsMap: poLineLabelsMap,
-  snapshotPath: 'orderLineSnapshot',
   id: 'orderLineVersions',
   onClose: jest.fn(),
   onSelectVersion: jest.fn(),
-  versions: [],
 };
 
-const renderVersionHistoryPane = (props = {}) => render(
-  <VersionHistoryPane
-    {...defaultProps}
-    {...props}
-  />,
+const renderVersionHistoryPane = ({
+  snapshotPath = 'orderLineSnapshot',
+  versionId,
+  versions = [],
+  ...props
+} = {}) => render(
+  <VersionViewContextProvider
+    snapshotPath={snapshotPath}
+    versionId={versionId}
+    versions={versions}
+  >
+    <VersionHistoryPane
+      {...defaultProps}
+      {...props}
+      versions={versions}
+    />
+  </VersionViewContextProvider>,
 );
 
 describe('VersionHistoryPane', () => {

--- a/lib/VersionHistory/VersionViewContext/VersionViewContext.js
+++ b/lib/VersionHistory/VersionViewContext/VersionViewContext.js
@@ -1,0 +1,38 @@
+import PropTypes from 'prop-types';
+import { createContext, useMemo } from 'react';
+import { get } from 'lodash';
+
+import { useVersionsDifference } from '@folio/stripes-acq-components';
+
+export const VersionViewContext = createContext();
+
+export const VersionViewContextProvider = ({
+  children,
+  snapshotPath,
+  versionId,
+  versions,
+}) => {
+  const { versionsMap, users: versionsUsers } = useVersionsDifference(versions, snapshotPath);
+  const { changes = [], paths = [] } = useMemo(() => get(versionsMap, versionId, {}) || {}, [versionId, versionsMap]);
+
+  const contextValue = {
+    changes,
+    paths,
+    versions,
+    versionsMap,
+    versionsUsers,
+  };
+
+  return (
+    <VersionViewContext.Provider value={contextValue}>
+      {children}
+    </VersionViewContext.Provider>
+  );
+};
+
+VersionViewContextProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+  snapshotPath: PropTypes.string.isRequired,
+  versionId: PropTypes.string.isRequired,
+  versions: PropTypes.arrayOf(PropTypes.object).isRequired,
+};

--- a/lib/VersionHistory/VersionViewContext/VersionViewContext.js
+++ b/lib/VersionHistory/VersionViewContext/VersionViewContext.js
@@ -15,16 +15,16 @@ export const VersionViewContextProvider = ({
   const { versionsMap, users: versionsUsers } = useVersionsDifference(versions, snapshotPath);
   const { changes = [], paths = [] } = useMemo(() => get(versionsMap, versionId, {}) || {}, [versionId, versionsMap]);
 
+  const contextValue = useMemo(() => ({
+    changes,
+    paths,
+    versions,
+    versionsMap,
+    versionsUsers,
+  }), [changes, paths, versions, versionsMap, versionsUsers]);
+
   return (
-    <VersionViewContext.Provider
-      value={{
-        changes,
-        paths,
-        versions,
-        versionsMap,
-        versionsUsers,
-      }}
-    >
+    <VersionViewContext.Provider value={contextValue}>
       {children}
     </VersionViewContext.Provider>
   );

--- a/lib/VersionHistory/VersionViewContext/VersionViewContext.js
+++ b/lib/VersionHistory/VersionViewContext/VersionViewContext.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import { createContext, useMemo } from 'react';
 import { get } from 'lodash';
 
-import { useVersionsDifference } from '@folio/stripes-acq-components';
+import { useVersionsDifference } from '../hooks';
 
 export const VersionViewContext = createContext();
 

--- a/lib/VersionHistory/VersionViewContext/VersionViewContext.js
+++ b/lib/VersionHistory/VersionViewContext/VersionViewContext.js
@@ -15,16 +15,16 @@ export const VersionViewContextProvider = ({
   const { versionsMap, users: versionsUsers } = useVersionsDifference(versions, snapshotPath);
   const { changes = [], paths = [] } = useMemo(() => get(versionsMap, versionId, {}) || {}, [versionId, versionsMap]);
 
-  const contextValue = {
-    changes,
-    paths,
-    versions,
-    versionsMap,
-    versionsUsers,
-  };
-
   return (
-    <VersionViewContext.Provider value={contextValue}>
+    <VersionViewContext.Provider
+      value={{
+        changes,
+        paths,
+        versions,
+        versionsMap,
+        versionsUsers,
+      }}
+    >
       {children}
     </VersionViewContext.Provider>
   );

--- a/lib/VersionHistory/VersionViewContext/index.js
+++ b/lib/VersionHistory/VersionViewContext/index.js
@@ -1,0 +1,1 @@
+export { VersionViewContext, VersionViewContextProvider } from './VersionViewContext';

--- a/lib/VersionHistory/getHighlightedFields.js
+++ b/lib/VersionHistory/getHighlightedFields.js
@@ -1,0 +1,28 @@
+import { FIELD_CHANGE_TYPES } from '../utils';
+
+/*
+  To check if the end of a path leads to an array element instead of an object key.
+
+  From the objects difference point of view it means that an element has been added (removed) to (from)
+  array (repeatable field), which means that the entire row in the MCL should be highlighted.
+*/
+const regExp = /.*\[\d\]$/;
+
+export const getHighlightedFields = ({ changes = [], fieldNames = [], name }) => {
+  return (
+    changes
+      .filter(({ path }) => String(path).startsWith(name))
+      .reduce((acc, curr) => {
+        const pathsMap = {
+          [FIELD_CHANGE_TYPES.create]: regExp.test(curr.path)
+            ? fieldNames.map((fieldName) => `${curr.path}.${fieldName}`)
+            : [curr.path],
+          [FIELD_CHANGE_TYPES.update]: [curr.path],
+        };
+
+        const paths = pathsMap[curr.type] || [];
+
+        return acc.concat(paths);
+      }, [])
+  );
+};

--- a/lib/VersionHistory/getHighlightedFields.js
+++ b/lib/VersionHistory/getHighlightedFields.js
@@ -11,7 +11,8 @@ const regExp = /\[\d\]$/;
 export const getHighlightedFields = ({ changes = [], fieldNames = [], name }) => {
   return (
     changes
-      .filter(({ path }) => String(path).startsWith(name))
+      // get changes only for the field with the specified "name"
+      .filter(({ path }) => new RegExp(`${name}(?:(?:\\.|\\[\\d\\])|$)`).test(path))
       .reduce((acc, curr) => {
         const pathsMap = {
           [FIELD_CHANGE_TYPES.create]: regExp.test(curr.path)

--- a/lib/VersionHistory/getHighlightedFields.js
+++ b/lib/VersionHistory/getHighlightedFields.js
@@ -6,7 +6,7 @@ import { FIELD_CHANGE_TYPES } from '../utils';
   From the objects difference point of view it means that an element has been added (removed) to (from)
   array (repeatable field), which means that the entire row in the MCL should be highlighted.
 */
-const regExp = /.*\[\d\]$/;
+const regExp = /\[\d\]$/;
 
 export const getHighlightedFields = ({ changes = [], fieldNames = [], name }) => {
   return (

--- a/lib/VersionHistory/getHighlightedFields.test.js
+++ b/lib/VersionHistory/getHighlightedFields.test.js
@@ -1,0 +1,38 @@
+import { FIELD_CHANGE_TYPES } from '../utils';
+import { getHighlightedFields } from './getHighlightedFields';
+
+const fieldNames = ['foo', 'bar', 'baz'];
+
+const changes = [
+  { type: FIELD_CHANGE_TYPES.update, path: 'fieldOne[0].foo' },
+  { type: FIELD_CHANGE_TYPES.create, path: 'fieldOne[1]' },
+  { type: FIELD_CHANGE_TYPES.update, path: 'field.two[0].baz' },
+  { type: FIELD_CHANGE_TYPES.create, path: 'field.two[1]' },
+  { type: FIELD_CHANGE_TYPES.create, path: 'fieldThree' },
+];
+
+describe('getHighlightedFields', () => {
+  it('should return highlights for field specified by name', () => {
+    const name = 'fieldOne';
+    const highlights = getHighlightedFields({ changes, fieldNames, name });
+
+    highlights.forEach((fieldPath) => {
+      expect(fieldPath.startsWith(name));
+    });
+  });
+
+  it('should highlight all related fields (whole row for MCL) for added repeatable field', () => {
+    const name = 'field.two';
+    const highlights = getHighlightedFields({ changes, fieldNames, name });
+
+    const fieldChanges = changes.filter(
+      ({ type, path }) => type === FIELD_CHANGE_TYPES.create && path.startsWith(name),
+    );
+
+    fieldChanges.forEach(({ path }) => {
+      fieldNames.forEach((fieldName) => {
+        expect(highlights.includes(`${path}.${fieldName}`)).toBeTruthy();
+      });
+    });
+  });
+});

--- a/lib/VersionHistory/getVersionWrappedFormatter.js
+++ b/lib/VersionHistory/getVersionWrappedFormatter.js
@@ -1,0 +1,26 @@
+import { getHighlightedFields } from './getHighlightedFields';
+
+export const getVersionWrappedFormatter = ({
+  baseFormatter,
+  changes,
+  fieldsMapping,
+  name,
+}) => {
+  const formatterEntries = Object.entries(baseFormatter);
+  const fieldNames = Object.values(fieldsMapping);
+
+  const highlights = getHighlightedFields({ changes, fieldNames, name });
+
+  return formatterEntries.reduce((acc, [colName, renderCell]) => {
+    return {
+      ...acc,
+      [colName]: ({ rowIndex, ...rest }) => {
+        const isUpdated = highlights.includes(`${name}[${rowIndex}].${fieldsMapping[colName]}`);
+
+        const content = renderCell({ rowIndex, ...rest });
+
+        return isUpdated ? <mark>{content}</mark> : content;
+      },
+    };
+  }, {});
+};

--- a/lib/VersionHistory/getVersionWrappedFormatter.test.js
+++ b/lib/VersionHistory/getVersionWrappedFormatter.test.js
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react';
+
+import { MultiColumnList } from '@folio/stripes/components';
+
+import { FIELD_CHANGE_TYPES } from '../utils';
+import { getVersionWrappedFormatter } from './getVersionWrappedFormatter';
+
+const changes = [
+  { type: FIELD_CHANGE_TYPES.update, path: 'fieldOne[0].name' },
+  { type: FIELD_CHANGE_TYPES.create, path: 'fieldOne[1]' },
+  { type: FIELD_CHANGE_TYPES.update, path: 'field.two[0].foo' },
+];
+
+const COLUMNS = { foo: 'foo' };
+const baseFormatter = { [COLUMNS.foo]: jest.fn(({ name }) => name) };
+const columnMapping = { [COLUMNS.foo]: 'Column head text' };
+const fieldsMapping = { foo: 'name' };
+const visibleColumns = [COLUMNS.foo];
+
+const contentData = [
+  { name: 'FooCell' },
+  { name: 'BarCell' },
+  { name: 'BazCell' },
+];
+
+const renderMCL = (props = {}) => render(
+  <MultiColumnList
+    contentData={contentData}
+    columnMapping={columnMapping}
+    visibleColumns={visibleColumns}
+    {...props}
+  />,
+);
+
+describe('getVersionWrappedFormatter', () => {
+  it('should call original formatter\'s handlers to mark updated cells in the current version', () => {
+    const name = 'fieldOne';
+    const formatter = getVersionWrappedFormatter({
+      baseFormatter,
+      changes,
+      fieldsMapping,
+      name,
+    });
+
+    renderMCL({ formatter });
+
+    Object.values(baseFormatter).forEach((handler) => {
+      expect(handler).toHaveBeenCalled();
+    });
+
+    expect(screen.getByText(contentData[0].name).tagName.toLowerCase()).toEqual('mark');
+    expect(screen.getByText(contentData[1].name).tagName.toLowerCase()).toEqual('mark');
+    expect(screen.getByText(contentData[2].name).tagName.toLowerCase()).not.toEqual('mark');
+  });
+});

--- a/lib/VersionHistory/hooks/useVersionWrappedFormatter/index.js
+++ b/lib/VersionHistory/hooks/useVersionWrappedFormatter/index.js
@@ -1,2 +1,1 @@
-export { useVersionsDifference } from './useVersionsDifference';
 export { useVersionWrappedFormatter } from './useVersionWrappedFormatter';

--- a/lib/VersionHistory/hooks/useVersionWrappedFormatter/useVersionWrappedFormatter.js
+++ b/lib/VersionHistory/hooks/useVersionWrappedFormatter/useVersionWrappedFormatter.js
@@ -1,0 +1,21 @@
+import { useContext, useMemo } from 'react';
+
+import { getVersionWrappedFormatter } from '../../getVersionWrappedFormatter';
+import { VersionViewContext } from '../../VersionViewContext';
+
+export const useVersionWrappedFormatter = ({ baseFormatter, name, fieldsMapping }) => {
+  const versionContext = useContext(VersionViewContext);
+
+  const formatter = useMemo(() => {
+    if (!versionContext || !name || !fieldsMapping) return baseFormatter;
+
+    return getVersionWrappedFormatter({
+      baseFormatter,
+      fieldsMapping,
+      name,
+      changes: versionContext.changes,
+    });
+  }, [baseFormatter, fieldsMapping, name, versionContext]);
+
+  return formatter;
+};

--- a/lib/VersionHistory/hooks/useVersionWrappedFormatter/useVersionWrappedFormatter.test.js
+++ b/lib/VersionHistory/hooks/useVersionWrappedFormatter/useVersionWrappedFormatter.test.js
@@ -1,0 +1,49 @@
+import { renderHook } from '@testing-library/react-hooks';
+
+import { orderAuditEvent } from '../../../../test/jest/fixtures';
+import { getVersionWrappedFormatter } from '../../getVersionWrappedFormatter';
+import { VersionViewContextProvider } from '../../VersionViewContext';
+import { useVersionWrappedFormatter } from './useVersionWrappedFormatter';
+
+jest.mock('../../getVersionWrappedFormatter', () => ({
+  getVersionWrappedFormatter: jest.fn(() => ({ foo: jest.fn() })),
+}));
+
+const fieldsMapping = { foo: 'name' };
+const baseFormatter = { foo: ({ name }) => name };
+const mockFormatter = {};
+
+// eslint-disable-next-line react/prop-types
+const wrapper = ({ children }) => (
+  <VersionViewContextProvider
+    versions={[orderAuditEvent]}
+    snapshotPath="orderSnapshot"
+  >
+    {children}
+  </VersionViewContextProvider>
+);
+
+describe('useVersionWrappedFormatter', () => {
+  beforeEach(() => {
+    getVersionWrappedFormatter.mockClear().mockReturnValue(mockFormatter);
+  });
+
+  it('should return base formatter when component is not wrapped by VersionViewContext', async () => {
+    const name = 'field.name';
+    const { result } = renderHook(
+      () => useVersionWrappedFormatter({ baseFormatter, name, fieldsMapping }),
+    );
+
+    expect(result.current).toBe(baseFormatter);
+  });
+
+  it('should return version wrapped formatter', async () => {
+    const name = 'field.name';
+    const { result } = renderHook(
+      () => useVersionWrappedFormatter({ baseFormatter, name, fieldsMapping }),
+      { wrapper },
+    );
+
+    expect(result.current).toBe(mockFormatter);
+  });
+});

--- a/lib/VersionHistory/index.js
+++ b/lib/VersionHistory/index.js
@@ -1,4 +1,7 @@
+export { getFieldLabels } from './getFieldLabels';
+export { getHighlightedFields } from './getHighlightedFields';
 export * from './hooks';
 export { VersionCard } from './VersionCard';
 export { VersionHistoryPane } from './VersionHistoryPane';
 export { VersionHistoryButton } from './VersionHistoryButton';
+export { VersionViewContext, VersionViewContextProvider } from './VersionViewContext';


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://issues.folio.org/browse/UISACQCOMP-132
## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
1. Implement context (`<VersionViewContext />`) and provider (`<VersionViewContextProvider />`) components to get the data of the current version of the entity;
2. Add a utilities that will wrap the MCL result formatter and mark cells for related updated fields in the current version:
    - `useVersionWrappedFormatter` hook - retrieve fields changes from version context and return updated formatter for MCLs based on `name` (field name in version snapshot), `fieldsMapping` (object map between MCL columns and MCL row field names), and `baseFormatter` (initial formatter to wrap). If there is no version context outside - returns base formatter;
    - `getVersionWrappedFormatter` - return wrapped formatter that mark MCL cells- for updated fields;
    - `getHighlightedFields` - return a list of field paths that should be highlighted in MCL;
3. Use `useVersionWrappedFormatter` hook to get wrapped result formatter in components (MCL) that should highlight updates in version view (`<FundDistributionView />`, `<ContributorDetails />`, `<ProductIdDetails />`, `<VendorReferenceNumbersDetails />`);

Demo: [thunderjet rancher](https://folio-dev-thunderjet-diku.ci.folio.org/orders/lines/view/a719f48b-569b-4393-9729-32ae0393bf81/versions/72729a06-e1e0-4da6-a5c5-c0d189e5fdb0?limit=50&offset=0&receiptStatus=Pending)

<details open>
  <summary>Preview</summary>

  ![image](https://user-images.githubusercontent.com/88109087/211086401-1df1bb05-147d-4163-b766-9e9f1b3c097c.png)

</details>

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
