### PR TITLE
UISACQCOMP-137 Upgrade react-redux to v8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Change history for stripes-acq-components
 
-## (IN PROGRESS)
+## (4.0.0 IN PROGRESS)
 
 * Add common util which will provide translations for `ControlledVocab`. Refs UISACQCOMP-123.
 * Change log: add common components to display version history on the fourth pane. Refs UISACQCOMP-129.
 * Change log: display all versions in fourth pane. Refs UISACQCOMP-131.
 * Show in version history record view, which fields have been edited. Refs UISACQCOMP-132.
 * Add ability to provide `notLoadedMessage` prop for `<NoResultsMessage>` component. Refs UISACQCOMP-136.
+* Upgrade `react-redux` to `v8`. Refs UISACQCOMP-137.
 
 ## [3.3.2](https://github.com/folio-org/stripes-acq-components/tree/v3.3.2) (2022-11-25)
 [Full Changelog](https://github.com/folio-org/stripes-acq-components/compare/v3.3.1...v3.3.2)

--- a/lib/DynamicSelection/DynamicSelection.test.js
+++ b/lib/DynamicSelection/DynamicSelection.test.js
@@ -44,7 +44,7 @@ describe('DynamicSelection', () => {
   it('should call debounced fetch function when \'onFilter\' was triggered', async () => {
     renderDynamicSelection();
 
-    const input = screen.getByLabelText('stripes-components.selection.filterOptionsLabel', {selector: 'input'});
+    const input = screen.getByLabelText('stripes-components.selection.filterOptionsLabel', { selector: 'input' });
 
     await act(async () => {
       user.type(input, '1');
@@ -57,7 +57,7 @@ describe('DynamicSelection', () => {
   it('should call \'onChange\' when an option from list was selected', async () => {
     renderDynamicSelection();
 
-    const input = screen.getByLabelText('stripes-components.selection.filterOptionsLabel', {selector: 'input'});
+    const input = screen.getByLabelText('stripes-components.selection.filterOptionsLabel', { selector: 'input' });
 
     await act(async () => {
       user.type(input, '1');

--- a/lib/DynamicSelection/DynamicSelection.test.js
+++ b/lib/DynamicSelection/DynamicSelection.test.js
@@ -44,7 +44,7 @@ describe('DynamicSelection', () => {
   it('should call debounced fetch function when \'onFilter\' was triggered', async () => {
     renderDynamicSelection();
 
-    const input = screen.getByLabelText('stripes-components.selection.filterOptionsLabel');
+    const input = screen.getByLabelText('stripes-components.selection.filterOptionsLabel', {selector: 'input'});
 
     await act(async () => {
       user.type(input, '1');
@@ -57,7 +57,7 @@ describe('DynamicSelection', () => {
   it('should call \'onChange\' when an option from list was selected', async () => {
     renderDynamicSelection();
 
-    const input = screen.getByLabelText('stripes-components.selection.filterOptionsLabel');
+    const input = screen.getByLabelText('stripes-components.selection.filterOptionsLabel', {selector: 'input'});
 
     await act(async () => {
       user.type(input, '1');

--- a/lib/DynamicSelectionFilter/DynamicSelectionFilter.test.js
+++ b/lib/DynamicSelectionFilter/DynamicSelectionFilter.test.js
@@ -56,7 +56,7 @@ describe('DynamicSelectionFilter', () => {
       renderDynamicSelectionFilter();
     });
 
-    const input = screen.getByLabelText('stripes-components.selection.filterOptionsLabel', {selector: 'input'});
+    const input = screen.getByLabelText('stripes-components.selection.filterOptionsLabel', { selector: 'input' });
 
     await act(async () => {
       user.type(input, '1');

--- a/lib/DynamicSelectionFilter/DynamicSelectionFilter.test.js
+++ b/lib/DynamicSelectionFilter/DynamicSelectionFilter.test.js
@@ -56,7 +56,7 @@ describe('DynamicSelectionFilter', () => {
       renderDynamicSelectionFilter();
     });
 
-    const input = screen.getByLabelText('stripes-components.selection.filterOptionsLabel');
+    const input = screen.getByLabelText('stripes-components.selection.filterOptionsLabel', {selector: 'input'});
 
     await act(async () => {
       user.type(input, '1');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-acq-components",
-  "version": "3.4.0",
+  "version": "4.0.0",
   "description": "Component library for Stripes Acquisitions modules",
   "publishConfig": {
     "registry": "https://repository.folio.org/repository/npm-folio/"
@@ -30,7 +30,7 @@
     "@babel/preset-typescript": "^7.13.0",
     "@bigtest/interactor": "^0.9.3",
     "@folio/eslint-config-stripes": "^6.1.0",
-    "@folio/stripes": "^7.0.0",
+    "@folio/stripes": "^8.0.0",
     "@folio/stripes-cli": "^2.4.0",
     "@formatjs/cli": "^4.2.6",
     "@testing-library/jest-dom": "^5.11.1",
@@ -52,7 +52,7 @@
     "react-dom": "^17.0.2",
     "react-intl": "^5.7.1",
     "react-query": "^3.6.0",
-    "react-redux": "^7.2.2",
+    "react-redux": "^8.0.5",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
     "redux": "^4.0.5"
@@ -79,10 +79,10 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-intl": "^5.7.1",
-    "react-redux": "*",
+    "react-redux": "^8.0.5",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
-    "redux": "*"
+    "redux": "^4.0.0"
   },
   "resolutions": {
     "@rehooks/local-storage": "2.4.0"


### PR DESCRIPTION
- Refs https://issues.folio.org/browse/UISACQCOMP-137.
- Upgrade will be happening across all of Stripes framework and modules that reference react-redux.
- v7 to v8 is a very harmless upgrade and is only considered breaking since they removed a few rarely used functions (which I confirmed we don't use). See https://github.com/reduxjs/react-redux/releases/tag/v8.0.0 for more details.