### PR TITLE
UISACQCOMP-143 Add the ability to get a list of all nested field names when comparing versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * *BREAKING*: Upgrade `react-redux` to `v8`. Refs UISACQCOMP-137.
 * Do not display version history cards without changes. Refs UISACQCOMP-139.
 * *BREAKING*: Update `@folio/stripes` to `8.0.0`. Refs UISACQCOMP-140.
+* Add the ability to get a list of all nested field names when comparing versions. Refs UISACQCOMP-143.
 
 ## [3.3.2](https://github.com/folio-org/stripes-acq-components/tree/v3.3.2) (2022-11-25)
 [Full Changelog](https://github.com/folio-org/stripes-acq-components/compare/v3.3.1...v3.3.2)

--- a/lib/VersionHistory/VersionHistoryPane/VersionHistoryPane.test.js
+++ b/lib/VersionHistory/VersionHistoryPane/VersionHistoryPane.test.js
@@ -15,8 +15,6 @@ jest.mock('../../hooks', () => ({
 const TEST_ID = 'testId';
 
 const poLineLabelsMap = {
-  'fundDistribution': 'ui-orders.line.accordion.fund',
-  'fundDistribution[\\d]': 'ui-orders.line.accordion.fund',
   'fundDistribution[\\d].fundId': 'stripes-acq-components.fundDistribution.name',
   'fundDistribution[\\d].code': 'stripes-acq-components.fundDistribution.name',
   'fundDistribution[\\d].expenseClassId': 'stripes-acq-components.fundDistribution.expenseClass',
@@ -97,7 +95,6 @@ describe('VersionHistoryPane', () => {
     // Changed fields
     expect(screen.getByText('stripes-acq-components.versionHistory.card.changed')).toBeInTheDocument();
     expect(screen.getByText('stripes-acq-components.fundDistribution.value')).toBeInTheDocument();
-    expect(screen.getByText('ui-orders.line.accordion.fund')).toBeInTheDocument();
   });
 
   it('should not display version cards without changed fields', () => {

--- a/lib/VersionHistory/VersionViewContext/VersionViewContext.js
+++ b/lib/VersionHistory/VersionViewContext/VersionViewContext.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import { createContext, useMemo } from 'react';
 import { get } from 'lodash';
 
-import { useVersionsDifference } from '../hooks';
+import { useVersionsDifference } from '../hooks/useVersionsDifference';
 
 export const VersionViewContext = createContext();
 

--- a/lib/VersionHistory/getVersionWrappedFormatter.js
+++ b/lib/VersionHistory/getVersionWrappedFormatter.js
@@ -1,21 +1,16 @@
-import { getHighlightedFields } from './getHighlightedFields';
-
 export const getVersionWrappedFormatter = ({
   baseFormatter,
-  changes,
   fieldsMapping,
   name,
+  paths,
 }) => {
   const formatterEntries = Object.entries(baseFormatter);
-  const fieldNames = Object.values(fieldsMapping);
-
-  const highlights = getHighlightedFields({ changes, fieldNames, name });
 
   return formatterEntries.reduce((acc, [colName, renderCell]) => {
     return {
       ...acc,
       [colName]: ({ rowIndex, ...rest }) => {
-        const isUpdated = highlights.includes(`${name}[${rowIndex}].${fieldsMapping[colName]}`);
+        const isUpdated = paths?.includes(`${name}[${rowIndex}].${fieldsMapping[colName]}`);
 
         const content = renderCell({ rowIndex, ...rest });
 

--- a/lib/VersionHistory/getVersionWrappedFormatter.test.js
+++ b/lib/VersionHistory/getVersionWrappedFormatter.test.js
@@ -7,9 +7,11 @@ import { getVersionWrappedFormatter } from './getVersionWrappedFormatter';
 
 const changes = [
   { type: FIELD_CHANGE_TYPES.update, path: 'fieldOne[0].name' },
-  { type: FIELD_CHANGE_TYPES.create, path: 'fieldOne[1]' },
+  { type: FIELD_CHANGE_TYPES.create, path: 'fieldOne[1].name' },
   { type: FIELD_CHANGE_TYPES.update, path: 'field.two[0].foo' },
 ];
+
+const paths = changes.map(({ path }) => path);
 
 const COLUMNS = { foo: 'foo' };
 const baseFormatter = { [COLUMNS.foo]: jest.fn(({ name }) => name) };
@@ -37,7 +39,7 @@ describe('getVersionWrappedFormatter', () => {
     const name = 'fieldOne';
     const formatter = getVersionWrappedFormatter({
       baseFormatter,
-      changes,
+      paths,
       fieldsMapping,
       name,
     });

--- a/lib/VersionHistory/hooks/useVersionWrappedFormatter/useVersionWrappedFormatter.js
+++ b/lib/VersionHistory/hooks/useVersionWrappedFormatter/useVersionWrappedFormatter.js
@@ -13,7 +13,7 @@ export const useVersionWrappedFormatter = ({ baseFormatter, name, fieldsMapping 
       baseFormatter,
       fieldsMapping,
       name,
-      changes: versionContext.changes,
+      paths: versionContext.paths,
     });
   }, [baseFormatter, fieldsMapping, name, versionContext]);
 

--- a/lib/VersionHistory/hooks/useVersionsDifference/useVersionsDifference.js
+++ b/lib/VersionHistory/hooks/useVersionsDifference/useVersionsDifference.js
@@ -1,7 +1,29 @@
-import { get, uniqBy } from 'lodash';
+import { get, isObject, uniqBy } from 'lodash';
 import { useMemo } from 'react';
 
-import { objectDifference } from '../../../utils';
+import {
+  FIELD_CHANGE_TYPES,
+  finalFormPathBuilder,
+  getObjectKey,
+  objectDifference,
+} from '../../../utils';
+
+const getNestedObjectKeys = (path, value) => {
+  if (!isObject(value)) return [path];
+
+  return Object
+    .entries(value)
+    .flatMap(([key, val]) => getNestedObjectKeys(
+      finalFormPathBuilder([path, getObjectKey(val, key)]),
+      val,
+    ));
+};
+
+const getNestedFieldPaths = (type, path, [oldValue, newValue]) => {
+  const targetValue = type === FIELD_CHANGE_TYPES.delete ? oldValue : newValue;
+
+  return getNestedObjectKeys(path, targetValue);
+};
 
 export const useVersionsDifference = (auditEvents, snapshotPath) => {
   const users = useMemo(() => uniqBy(auditEvents.map(({ userId, username }) => ({ id: userId, username })), 'id'), [auditEvents]);
@@ -11,15 +33,21 @@ export const useVersionsDifference = (auditEvents, snapshotPath) => {
 
     acc[event.id] = (i === (auditEvents.length - 1))
       ? null
-      : objectDifference(get(auditEvents[i + 1], snapshotPath, {}), snapshot).reduce((accum, item) => {
-        accum.changes.push(item);
-        accum.paths.push(item.path);
+      : objectDifference(get(auditEvents[i + 1], snapshotPath, {}), snapshot)
+        .reduce((accum, item) => {
+          const { path, type, values } = item;
+          const paths = type === FIELD_CHANGE_TYPES.update
+            ? [path]
+            : getNestedFieldPaths(type, path, values);
 
-        return accum;
-      }, {
-        changes: [],
-        paths: [],
-      });
+          accum.changes.push(item);
+          accum.paths.push(...paths);
+
+          return accum;
+        }, {
+          changes: [],
+          paths: [],
+        });
 
     return acc;
   }, {}), [auditEvents, snapshotPath]);

--- a/lib/VersionHistory/hooks/useVersionsDifference/useVersionsDifference.test.js
+++ b/lib/VersionHistory/hooks/useVersionsDifference/useVersionsDifference.test.js
@@ -16,6 +16,7 @@ describe('useVersionsDifference', () => {
     const { result } = renderHook(() => useVersionsDifference([clonedAudirEvent, orderAuditEvent], 'orderSnapshot'));
 
     expect(result.current).toEqual({
+      users: [{ id: clonedAudirEvent.userId, username: clonedAudirEvent.username }],
       versionsMap: {
         [orderAuditEvent.id]: null,
         [clonedAudirEvent.id]: {

--- a/lib/VersionHistory/hooks/useVersionsDifference/useVersionsDifference.test.js
+++ b/lib/VersionHistory/hooks/useVersionsDifference/useVersionsDifference.test.js
@@ -16,7 +16,6 @@ describe('useVersionsDifference', () => {
     const { result } = renderHook(() => useVersionsDifference([clonedAudirEvent, orderAuditEvent], 'orderSnapshot'));
 
     expect(result.current).toEqual({
-      users: [{ id: clonedAudirEvent.userId, username: clonedAudirEvent.username }],
       versionsMap: {
         [orderAuditEvent.id]: null,
         [clonedAudirEvent.id]: {
@@ -29,5 +28,39 @@ describe('useVersionsDifference', () => {
         },
       },
     });
+  });
+
+  it('should return paths for all created or deleted fields with nesting', () => {
+    const event = {
+      id: 'event-id',
+      username: 'testuser',
+      snapshot: {
+        id: 'test-id',
+        notNestingField: 'Hello',
+        fieldWithNesting: {
+          first: 'first field',
+          second: 'second field',
+        },
+      },
+    };
+
+    const clonedEvent = Object.assign(cloneDeep(event), { id: 'clonedEventId', username: 'testuser' });
+
+    set(clonedEvent.snapshot, 'fanotherFeldWithNesting', { foo: 'bar' });
+    set(clonedEvent.snapshot, 'notNestingField', 'value');
+    unset(clonedEvent.snapshot, 'fieldWithNesting');
+
+    const { result } = renderHook(() => useVersionsDifference([clonedEvent, event], 'snapshot'));
+
+    const { versionsMap } = result.current;
+
+    expect(versionsMap[clonedEvent.id]).toEqual(expect.objectContaining({
+      paths: expect.arrayContaining([
+        'notNestingField',
+        'fanotherFeldWithNesting.foo', // added in the object
+        'fieldWithNesting.first', // removed from the object
+        'fieldWithNesting.second', // removed from the object
+      ]),
+    }));
   });
 });

--- a/lib/utils/objectDifference/index.js
+++ b/lib/utils/objectDifference/index.js
@@ -1,1 +1,6 @@
-export { FIELD_CHANGE_TYPES, objectDifference } from './objectDifference';
+export {
+  FIELD_CHANGE_TYPES,
+  finalFormPathBuilder,
+  getObjectKey,
+  objectDifference,
+} from './objectDifference';

--- a/lib/utils/objectDifference/objectDifference.js
+++ b/lib/utils/objectDifference/objectDifference.js
@@ -6,7 +6,8 @@ import {
 } from 'lodash';
 
 const isEmptyObject = (value) => isObject(value) && isEmpty(value);
-const getObjectKey = (obj, key) => (
+
+export const getObjectKey = (obj, key) => (
   Array.isArray(obj) && Number.isInteger(+key)
     ? Number(key)
     : key


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://issues.folio.org/browse/UISACQCOMP-143

The `objectDifference` comparison algorithm returns the path to the changed key in the object. But the Value of this key can also contain nested objects (including arrays) whose keys should be highlighted when the version history view is displayed.

![image](https://user-images.githubusercontent.com/88109087/218706285-784fa23b-e061-4608-83b8-bb09dd4b230f.png)

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
When adding or removing a key from an object, the value of that key may not be the end value (primitive) that should be highlighted in the version history view, but a nested object or array. Therefore, for the version history, we need to get all the fields that have been added or removed.
<!-- OPTIONAL
#### TODOS and Open Questions
 [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
