### PR TITLE
UISACQCOMP-138 unpin @rehooks/local-storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## (4.1.0 IN PROGRESS)
 
+* Unpin `@rehooks/local-storage` now that it's no longer broken. Refs UISACQCOMP-138.
+
 ## [4.0.0](https://github.com/folio-org/stripes-acq-components/tree/v4.0.0) (2023-02-15)
 [Full Changelog](https://github.com/folio-org/stripes-acq-components/compare/v3.3.2...v4.0.0)
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "redux": "^4.0.5"
   },
   "dependencies": {
-    "@rehooks/local-storage": "^2.4.0",
+    "@rehooks/local-storage": "^2.4.4",
     "classnames": "^2.2.5",
     "dom-helpers": "^3.4.0",
     "final-form": "^4.18.2",
@@ -83,9 +83,6 @@
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
     "redux": "^4.0.0"
-  },
-  "resolutions": {
-    "@rehooks/local-storage": "2.4.0"
   },
   "stripes": {
     "actsAs": [


### PR DESCRIPTION
`@rehooks/local-storage` is no longer broken so we can once again depend on the latest version of it, allowing us to remove `resolutions` entries for it that are scattered about.

Attn: @NikitaSedyx I don't have write privileges in this repository. Please merge this if it looks good to you. 

Refs [UISACQCOMP-138](https://issues.folio.org/browse/UISACQCOMP-138)