### PR TITLE
UISACQCOMP-145 Escape quotes `"` and backslash `\` characters in search queries.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## (4.1.0 IN PROGRESS)
 
+* Escape quotes `"` and backslash `\` characters in search queries. Refs UISACQCOMP-145.
+
 ## [4.0.1](https://github.com/folio-org/stripes-acq-components/tree/v4.0.1) (2023-03-09)
 [Full Changelog](https://github.com/folio-org/stripes-acq-components/compare/v4.0.0...v4.0.1)
 

--- a/lib/AcqList/utils/queryUtils.js
+++ b/lib/AcqList/utils/queryUtils.js
@@ -1,5 +1,10 @@
-import { omit } from 'lodash';
 import moment from 'moment';
+import {
+  identity,
+  omit,
+} from 'lodash';
+
+import { escapeCqlValue } from '@folio/stripes/util';
 
 import { emptyArrayFilterValue } from '../../constants';
 import {
@@ -58,8 +63,14 @@ export const getFiltersCount = (filters) => {
   return filters && Object.keys(getFilterParams(filters)).filter(k => filters[k] !== undefined).length;
 };
 
-export const buildFilterQuery = (queryParams, getSearchQuery, customFilterMap = {}) => {
+export const buildFilterQuery = (
+  queryParams,
+  getSearchQuery,
+  customFilterMap = {},
+  escapeCql = true,
+) => {
   const filterParams = getFilterParams(queryParams);
+  const escapeFn = escapeCql ? escapeCqlValue : identity;
 
   return Object.keys(filterParams).map((filterKey) => {
     const filterValue = queryParams[filterKey];
@@ -68,7 +79,9 @@ export const buildFilterQuery = (queryParams, getSearchQuery, customFilterMap = 
     if (!filterValue) return false;
 
     if (filterKey === SEARCH_PARAMETER && filterValue) {
-      return `(${getSearchQuery(filterValue, queryParams[SEARCH_INDEX_PARAMETER])})`;
+      const searchQuery = getSearchQuery(escapeFn(filterValue), queryParams[SEARCH_INDEX_PARAMETER]);
+
+      return `(${searchQuery})`;
     }
 
     if (buildCustomFilterQuery) {
@@ -101,9 +114,16 @@ export const connectQuery = (filterQuery, sortingQuery) => {
   return filterQuery;
 };
 
-export const makeQueryBuilder = (searchAllQuery, getSearchQuery, defaultSorting, customFilterMap, customSortMap) => {
+export const makeQueryBuilder = (
+  searchAllQuery,
+  getSearchQuery,
+  defaultSorting,
+  customFilterMap,
+  customSortMap,
+  escapeCql,
+) => {
   return (queryParams) => {
-    const filterQuery = buildFilterQuery(queryParams, getSearchQuery, customFilterMap) || searchAllQuery;
+    const filterQuery = buildFilterQuery(queryParams, getSearchQuery, customFilterMap, escapeCql) || searchAllQuery;
     const sortingQuery = buildSortingQuery(queryParams, customSortMap) || defaultSorting;
 
     return connectQuery(filterQuery, sortingQuery);

--- a/lib/AcqList/utils/queryUtils.test.js
+++ b/lib/AcqList/utils/queryUtils.test.js
@@ -55,4 +55,28 @@ describe('queryUtils', () => {
         .toEqual(String.raw`("he\\o wor\d") and good=="mood"`);
     });
   });
+
+  describe('makeQueryBuilder', () => {
+    const searchAllQuery = 'cql.allRecords=1';
+    const defaultSorting = 'sortby name/sort.ascending';
+    const queryParams = {
+      [SEARCH_PARAMETER]: String.raw`"he\\o wor\d"`,
+      good: 'mood',
+      bad: undefined,
+    };
+
+    const buildQuery = queryUtils.makeQueryBuilder(
+      searchAllQuery,
+      identity,
+      defaultSorting,
+      {},
+      {},
+      false,
+    );
+
+    it('should return a function, which will build query string based on query parameters', () => {
+      expect(buildQuery(queryParams))
+        .toEqual(`${String.raw`(("he\\o wor\d") and good=="mood")`} ${defaultSorting}`);
+    });
+  });
 });

--- a/lib/AcqList/utils/queryUtils.test.js
+++ b/lib/AcqList/utils/queryUtils.test.js
@@ -1,7 +1,11 @@
 import moment from 'moment';
+import identity from 'lodash/identity';
 import * as queryUtils from './queryUtils';
 
-import { DATE_RANGE_FILTER_FORMAT } from '../constants';
+import {
+  DATE_RANGE_FILTER_FORMAT,
+  SEARCH_PARAMETER,
+} from '../constants';
 
 describe('queryUtils', () => {
   describe('buildDateTimeRangeQuery', () => {
@@ -31,6 +35,24 @@ describe('queryUtils', () => {
       expect(
         queryUtils.buildNumberRangeQuery('amount', '10-100'),
       ).toEqual('(amount >=/number 10 and amount <=/number 100)');
+    });
+  });
+
+  describe('buildFilterQuery', () => {
+    const queryParams = {
+      [SEARCH_PARAMETER]: String.raw`"he\\o wor\d"`,
+      good: 'mood',
+      bad: undefined,
+    };
+
+    it('should return search query with escaped quotes and backslashes', () => {
+      expect(queryUtils.buildFilterQuery(queryParams, identity))
+        .toEqual(String.raw`(\"he\\\\o wor\\d\") and good=="mood"`);
+    });
+
+    it('should return search query with raw value (without escaping)', () => {
+      expect(queryUtils.buildFilterQuery(queryParams, identity, {}, false))
+        .toEqual(String.raw`("he\\o wor\d") and good=="mood"`);
     });
   });
 });


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://issues.folio.org/browse/UISACQCOMP-145

If CQL query contains either `"` or `\` as it is (without escaping), then it may crush common requests to BE.
## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
Add boolean parameter `escapeCql` for `buildFilterQuery` function and if it equals true then escape `\` and `"` in CQL search query. Thus, it remains possible to keep the string in its original form without escaping.

<!-- OPTIONAL
#### TODOS and Open Questions
 [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
