### PR TITLE
UISACQCOMP-148 'Reset all' button remains enabled after clicking it to clear filtering results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Link to vendor organization record from organization value. Refs UISACQCOMP-147.
 * Add dependencies argument in the custom hook useLocationSorting. Refs UISACQCOMP-149
+* "Reset all" button remains enabled after clicking it to clear filtering results. Refs UISACQCOMP-148.
 
 ## [4.0.2](https://github.com/folio-org/stripes-acq-components/tree/v4.0.2) (2023-03-17)
 [Full Changelog](https://github.com/folio-org/stripes-acq-components/compare/v4.0.1...v4.0.2)

--- a/lib/AcqList/hooks/usePagination/usePagination.js
+++ b/lib/AcqList/hooks/usePagination/usePagination.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useLocation, useHistory } from 'react-router';
 
 import { usePrevious } from '../../../utils';
@@ -11,6 +11,7 @@ import {
   buildSearch,
   buildPaginatelessSearch,
   buildPaginationObj,
+  buildPaginatingSearch,
 } from '../../utils';
 
 const getTimestamp = () => (new Date()).valueOf();
@@ -19,42 +20,72 @@ export const usePagination = (defaultPagination = {}) => {
   const location = useLocation();
   const history = useHistory();
 
-  const initPagination = buildPaginationObj(location.search, defaultPagination);
+  const initPagination = useMemo(() => buildPaginationObj(location.search, defaultPagination), []);
 
   const [pagination, setPagination] = useState({ ...initPagination, timestamp: getTimestamp() });
   const prevPagination = usePrevious(pagination);
 
-  const paginatelessSearch = buildPaginatelessSearch(location.search);
+  const paginatelessSearch = useMemo(() => buildPaginatelessSearch(location.search), [location.search]);
   const prevPaginatelessSearch = usePrevious(paginatelessSearch);
 
-  useEffect(() => {
-    if (prevPaginatelessSearch !== undefined && prevPaginatelessSearch !== paginatelessSearch) {
-      setPagination((p) => ({ ...p, offset: 0, timestamp: getTimestamp() }));
-    }
-  }, [prevPaginatelessSearch, paginatelessSearch]);
+  const paginatingSearch = useMemo(() => buildPaginatingSearch(location.search), [location.search]);
+  const prevPaginatingSearch = usePrevious(paginatingSearch);
+
+  const updateLocation = useCallback((_pagination, search) => {
+    history.push({
+      pathname: '',
+      search: buildSearch(
+        {
+          [OFFSET_PARAMETER]: String(_pagination.offset),
+          [LIMIT_PARAMETER]: String(_pagination.limit),
+        },
+        search,
+      ),
+    });
+  }, [history]);
 
   useEffect(() => {
-    if (prevPagination && prevPagination !== pagination) {
-      history.push({
-        pathname: '',
-        search: buildSearch(
-          {
-            [OFFSET_PARAMETER]: String(pagination.offset),
-            [LIMIT_PARAMETER]: String(pagination.limit),
-          },
-          location.search,
-        ),
+    // Reset pagination and update location when filters (without 'limit' and 'offset' search params) were changed
+    if (prevPaginatelessSearch !== undefined && prevPaginatelessSearch !== paginatelessSearch) {
+      setPagination((p) => {
+        const newPagination = { ...p, [OFFSET_PARAMETER]: 0, timestamp: getTimestamp() };
+
+        // Not update location if search was cleared (basically means, that all filters were reset)
+        if (location.search) {
+          updateLocation(newPagination, location.search);
+        }
+
+        return newPagination;
       });
     }
-  }, [prevPagination, pagination, history, location.search]);
+  }, [prevPaginatelessSearch, paginatelessSearch, history, location.search, prevPagination, updateLocation]);
+
+  useEffect(() => {
+    // Reset pagination, when there were no filters, but pagination params were cleared
+    if (!prevPaginatelessSearch && !paginatingSearch && prevPaginatingSearch) {
+      setPagination((p) => ({ ...p, [OFFSET_PARAMETER]: 0 }));
+    }
+  }, [paginatingSearch, prevPaginatelessSearch, prevPaginatingSearch]);
 
   const refreshPage = useCallback(() => {
-    setPagination((p) => ({ ...p, timestamp: getTimestamp() }));
-  }, []);
+    setPagination((p) => {
+      const newPagination = { ...p, timestamp: getTimestamp() };
 
-  const changePage = useCallback((newPagination) => {
-    setPagination((p) => ({ ...p, ...newPagination }));
-  }, []);
+      updateLocation(newPagination, location.search);
+
+      return newPagination;
+    });
+  }, [location.search, updateLocation]);
+
+  const changePage = useCallback((_pagination) => {
+    setPagination((p) => {
+      const newPagination = { ...p, ..._pagination };
+
+      updateLocation(newPagination, location.search);
+
+      return newPagination;
+    });
+  }, [location.search, updateLocation]);
 
   return {
     pagination,

--- a/lib/AcqList/hooks/usePagination/usePagination.js
+++ b/lib/AcqList/hooks/usePagination/usePagination.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useLocation, useHistory } from 'react-router';
 
 import { usePrevious } from '../../../utils';
@@ -20,15 +20,15 @@ export const usePagination = (defaultPagination = {}) => {
   const location = useLocation();
   const history = useHistory();
 
-  const initPagination = useMemo(() => buildPaginationObj(location.search, defaultPagination), []);
+  const initPagination = buildPaginationObj(location.search, defaultPagination);
 
   const [pagination, setPagination] = useState({ ...initPagination, timestamp: getTimestamp() });
   const prevPagination = usePrevious(pagination);
 
-  const paginatelessSearch = useMemo(() => buildPaginatelessSearch(location.search), [location.search]);
+  const paginatelessSearch = buildPaginatelessSearch(location.search);
   const prevPaginatelessSearch = usePrevious(paginatelessSearch);
 
-  const paginatingSearch = useMemo(() => buildPaginatingSearch(location.search), [location.search]);
+  const paginatingSearch = buildPaginatingSearch(location.search);
   const prevPaginatingSearch = usePrevious(paginatingSearch);
 
   const updateLocation = useCallback((_pagination, search) => {

--- a/lib/AcqList/utils/searchUtils.js
+++ b/lib/AcqList/utils/searchUtils.js
@@ -1,4 +1,5 @@
 import queryString from 'query-string';
+import { pick } from 'lodash';
 
 import {
   SEARCH_PARAMETER,
@@ -24,6 +25,10 @@ export const buildSearch = (newQueryParams, searchString) => {
 
 export const buildPaginatelessSearch = (searchString) => {
   return buildSearch({ [OFFSET_PARAMETER]: 0, [LIMIT_PARAMETER]: 0 }, searchString);
+};
+
+export const buildPaginatingSearch = (searchString) => {
+  return queryString.stringify(pick(queryString.parse(searchString), [OFFSET_PARAMETER, LIMIT_PARAMETER]));
 };
 
 export const buildFiltersObj = (searchString) => {


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://issues.folio.org/browse/UISACQCOMP-148

In all ACQ apps, the state of the "Reset all" button relies on the location search: if the search is empty, the button is disabled. In addition to filters, a pagination hook also works with a search, which changes the search when changing filters or a page.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
Keep the `search` empty when 'reset all' button was triggered.

![chrome_zizcVhs43U](https://github.com/folio-org/stripes-acq-components/assets/88109087/dedb7d86-7f43-44ba-a476-cc3e8a48cf6b)

<!-- OPTIONAL
#### TODOS and Open Questions
 [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
