### PR TITLE
UINV-479 - get expanse classes with fiscalYearId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Link to vendor organization record from organization value. Refs UISACQCOMP-147.
 * Add dependencies argument in the custom hook useLocationSorting. Refs UISACQCOMP-149
+* Allow user to select Fund and Expense class from Fiscal year specified in invoice. Refs UINV-479.
 
 ## [4.0.2](https://github.com/folio-org/stripes-acq-components/tree/v4.0.2) (2023-03-17)
 [Full Changelog](https://github.com/folio-org/stripes-acq-components/compare/v4.0.1...v4.0.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 * "Reset all" button remains enabled after clicking it to clear filtering results. Refs UISACQCOMP-148.
 * Allow user to select Fund and Expense class from Fiscal year specified in invoice. Refs UINV-479.
 
-
 ## [4.0.2](https://github.com/folio-org/stripes-acq-components/tree/v4.0.2) (2023-03-17)
 [Full Changelog](https://github.com/folio-org/stripes-acq-components/compare/v4.0.1...v4.0.2)
 

--- a/lib/FundDistribution/FundDistributionFields/FundDistributionFieldsFinalContainer.js
+++ b/lib/FundDistribution/FundDistributionFields/FundDistributionFieldsFinalContainer.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { stripesConnect } from '@folio/stripes/core';
 import { Loading } from '@folio/stripes/components';
 
+import { uniqBy } from 'lodash';
 import {
   fundsManifest,
   fundExpenseClassesManifest,
@@ -19,6 +20,7 @@ const FundDistributionFieldsFinalContainer = ({
   change,
   currency,
   disabled,
+  fiscalYearId,
   fundDistribution,
   mutator: originMutator,
   name,
@@ -27,35 +29,61 @@ const FundDistributionFieldsFinalContainer = ({
   stripes,
   totalAmount,
   validate,
+  formValues,
   validateFundDistributionTotal,
 }) => {
   // eslint-disable-next-line react-hooks/exhaustive-deps
+
   const mutator = useMemo(() => originMutator, []);
   const funds = resources?.[DICT_FUNDS]?.records;
   const fundCodes = useMemo(() => funds && new Map(funds.map(f => [f.id, f.code])), [funds]);
   const [expenseClassesByFundId, setExpenseClassesByFundId] = useState({});
 
   useEffect(() => {
-    const expenseClassesFundsToFetch = fundDistribution?.filter(({ fundId }) => (
-      fundId && !expenseClassesByFundId[fundId]
-    ));
+    const uniqueFundDistribution = uniqBy(fundDistribution, 'fundId');
 
-    if (expenseClassesFundsToFetch?.length) {
-      expenseClassesFundsToFetch.forEach(({ fundId }) => fetchExpenseClasses(
-        fundId, expenseClassesByFundId, setExpenseClassesByFundId, mutator.fundExpenseClasses,
-      ));
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [fundDistribution, expenseClassesByFundId]);
+    uniqueFundDistribution.forEach(({ fundId }) => fetchExpenseClasses({
+      fundId,
+      fiscalYearId,
+      setExpenseClassesByFundId,
+      mutator: mutator.fundExpenseClasses,
+    }));
+  }, [fundDistribution, fiscalYearId, mutator.fundExpenseClasses]);
+
+  const resetExpenseClasses = useCallback(() => {
+    formValues?.adjustments?.forEach((adjustment, index) => {
+      const { fundDistributions } = adjustment;
+
+      // reset form field state if fundId is changed and there is no expense class for this fund
+      fundDistributions?.forEach(({ fundId, expenseClassId }, distributionIndex) => {
+        const fieldName = `adjustments[${index}].fundDistributions[${distributionIndex}]`;
+
+        if (!expenseClassId) return;
+        const isExpenseClassExist = expenseClassesByFundId[fundId]?.find(({ id }) => id === expenseClassId);
+
+        if (!isExpenseClassExist) {
+          change(`${fieldName}.expenseClassId`, null);
+        }
+      });
+    });
+  }, [change, expenseClassesByFundId, formValues?.adjustments]);
+
+  useEffect(() => {
+    resetExpenseClasses();
+  }, [expenseClassesByFundId, resetExpenseClasses, fiscalYearId]);
 
   const onSelectFund = useCallback((fieldName, fundId) => {
     change(`${fieldName}.fundId`, fundId || null);
     change(`${fieldName}.code`, fundCodes.get(fundId) || null);
     change(`${fieldName}.encumbrance`, null);
 
-    fetchExpenseClasses(
-      fundId, expenseClassesByFundId, setExpenseClassesByFundId, mutator.fundExpenseClasses,
-    ).then((classesResponse) => {
+    fetchExpenseClasses({
+      fundId,
+      fiscalYearId,
+      expenseClassesByFundId,
+      setExpenseClassesByFundId,
+      mutator: mutator.fundExpenseClasses,
+    }).then((classesResponse) => {
       let preselectedExpenseClassId = null;
 
       if (classesResponse?.length === 1) {
@@ -65,7 +93,7 @@ const FundDistributionFieldsFinalContainer = ({
     }).catch(() => {
       change(`${fieldName}.expenseClassId`, null);
     });
-  }, [change, expenseClassesByFundId, fundCodes, mutator.fundExpenseClasses]);
+  }, [change, expenseClassesByFundId, fundCodes, mutator.fundExpenseClasses, fiscalYearId]);
 
   const onChangeToAmount = useCallback(distributionTypeFieldName => {
     change(distributionTypeFieldName.replace('distributionType', 'value'), null);
@@ -101,9 +129,6 @@ const FundDistributionFieldsFinalContainer = ({
 FundDistributionFieldsFinalContainer.manifest = Object.freeze({
   fundExpenseClasses: {
     ...fundExpenseClassesManifest,
-    params: {
-      status: 'Active',
-    },
   },
   [DICT_FUNDS]: fundsManifest,
 });
@@ -116,11 +141,13 @@ FundDistributionFieldsFinalContainer.propTypes = {
   mutator: PropTypes.object.isRequired,
   name: PropTypes.string.isRequired,
   required: PropTypes.bool,
+  fiscalYearId: PropTypes.string,
   resources: PropTypes.object.isRequired,
   stripes: PropTypes.object.isRequired,
   totalAmount: PropTypes.number,
   validate: PropTypes.func,
   validateFundDistributionTotal: PropTypes.func,
+  formValues: PropTypes.object.isRequired,
 };
 
 FundDistributionFieldsFinalContainer.defaultProps = {

--- a/lib/FundDistribution/FundDistributionFields/FundDistributionFieldsFinalContainer.js
+++ b/lib/FundDistribution/FundDistributionFields/FundDistributionFieldsFinalContainer.js
@@ -51,9 +51,7 @@ const FundDistributionFieldsFinalContainer = ({
   }, [fundDistribution, fiscalYearId, mutator.fundExpenseClasses]);
 
   const resetExpenseClasses = useCallback(() => {
-    formValues?.adjustments?.forEach((adjustment, index) => {
-      const { fundDistributions } = adjustment;
-
+    formValues?.adjustments?.forEach(({ fundDistributions }, index) => {
       // reset form field state if fundId is changed and there is no expense class for this fund
       fundDistributions?.forEach(({ fundId, expenseClassId }, distributionIndex) => {
         const fieldName = `adjustments[${index}].fundDistributions[${distributionIndex}]`;

--- a/lib/FundDistribution/FundDistributionFields/FundDistributionFieldsFinalContainer.js
+++ b/lib/FundDistribution/FundDistributionFields/FundDistributionFieldsFinalContainer.js
@@ -67,8 +67,11 @@ const FundDistributionFieldsFinalContainer = ({
   }, [change, expenseClassesByFundId, formValues?.adjustments]);
 
   useEffect(() => {
-    resetExpenseClasses();
-  }, [expenseClassesByFundId, resetExpenseClasses, fiscalYearId]);
+    // prevent reset expense class on edit if there is selected expense class on initial load
+    if (Object.values(expenseClassesByFundId).length > 0) {
+      resetExpenseClasses();
+    }
+  }, [expenseClassesByFundId, fiscalYearId, resetExpenseClasses]);
 
   const onSelectFund = useCallback((fieldName, fundId) => {
     change(`${fieldName}.fundId`, fundId || null);

--- a/lib/FundDistribution/FundDistributionFields/FundDistributionFieldsFinalContainer.test.js
+++ b/lib/FundDistribution/FundDistributionFields/FundDistributionFieldsFinalContainer.test.js
@@ -110,6 +110,6 @@ describe('FundDistributionFieldsFinalContainer', () => {
       },
       'path': 'finance/funds/fundId/expense-classes',
     });
-    expect(change).toHaveBeenCalledWith('adjustments[0].fundDistributions[0].expenseClassId', null);
+    await waitFor(() => expect(change).toHaveBeenCalledWith('adjustments[0].fundDistributions[0].expenseClassId', null));
   });
 });

--- a/lib/FundDistribution/FundDistributionFields/FundDistributionFieldsFinalContainer.test.js
+++ b/lib/FundDistribution/FundDistributionFields/FundDistributionFieldsFinalContainer.test.js
@@ -75,4 +75,41 @@ describe('FundDistributionFieldsFinalContainer', () => {
     FundDistributionFieldsFinal.mock.calls[0][0].onChangeToPercent('fieldName');
     expect(change).toHaveBeenCalled();
   });
+
+  it('should fetch expense classes with fiscalYearId on fund select and reset expenseClassId', async () => {
+    renderComponent({
+      change,
+      mutator,
+      fiscalYearId: 'fiscalYearId',
+      formValues: {
+        adjustments: [
+          {
+            'type': 'Amount',
+            'relationToTotal': 'In addition to',
+            'prorate': 'Not prorated',
+            'fundDistributions': [
+              {
+                'distributionType': 'percentage',
+                'value': 100,
+                'fundId': '7fbd5d84-62d1-44c6-9c45-6cb173998bbd',
+                'code': 'AFRICAHIST',
+                'encumbrance': null,
+                'expenseClassId': '1bcc3247-99bf-4dca-9b0f-7bc51a2998c2',
+              },
+            ],
+          },
+        ],
+      },
+    });
+    FundDistributionFieldsFinal.mock.calls[0][0].onSelectFund('fieldName', 'fundId');
+
+    expect(mutator.fundExpenseClasses.GET).toHaveBeenCalledWith({
+      'params': {
+        'fiscalYearId': 'fiscalYearId',
+        'status': 'Active',
+      },
+      'path': 'finance/funds/fundId/expense-classes',
+    });
+    expect(change).toHaveBeenCalledWith('adjustments[0].fundDistributions[0].expenseClassId', null);
+  });
 });

--- a/lib/FundDistribution/FundDistributionFields/fetchExpenseClasses.js
+++ b/lib/FundDistribution/FundDistributionFields/fetchExpenseClasses.js
@@ -1,23 +1,30 @@
 import { sortBy } from 'lodash';
 
-export async function fetchExpenseClasses(fundId, expenseClassesByFundId, setExpenseClassesByFundId, mutator) {
+export async function fetchExpenseClasses({
+  fundId,
+  mutator,
+  fiscalYearId,
+  setExpenseClassesByFundId,
+}) {
   let classes = null;
 
   if (fundId) {
-    classes = expenseClassesByFundId[fundId];
-
-    if (!classes) {
-      try {
-        classes = await mutator.GET({ path: `finance/funds/${fundId}/expense-classes` });
-      } catch {
-        classes = [];
-      }
-
-      setExpenseClassesByFundId((prevClasses) => ({
-        ...prevClasses,
-        [fundId]: sortBy(classes, ({ name }) => name.toLowerCase()),
-      }));
+    try {
+      classes = await mutator.GET({
+        path: `finance/funds/${fundId}/expense-classes`,
+        params: {
+          status: 'Active',
+          fiscalYearId,
+        },
+      });
+    } catch {
+      classes = [];
     }
+
+    setExpenseClassesByFundId((prevClasses) => ({
+      ...prevClasses,
+      [fundId]: sortBy(classes, ({ name }) => name.toLowerCase()),
+    }));
   }
 
   return classes;


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
[UINV-479](https://issues.folio.org/browse/UINV-479) - Allow user to select Fund and Expense class from Fiscal year specified in invoice.
Sub PR for the ticket https://github.com/folio-org/ui-invoice/pull/698
## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- pass `fiscalYearId` for `FundDistributionFieldsFinalContainer` component
- pass `formValues` for  `FundDistributionFieldsFinalContainer` component
- on `fiscalYearId` changes reset expanse class id if not belong to the current `fiscalYearId`
- ### [Video source](https://epam-my.sharepoint.com/:v:/p/alisher_musurmonov1/EYXZQrxtsfBKkqCHn8SqBr8BjcKBT_FoGAre9VVkdpH3dg?e=3RmFyT)
<!-- OPTIONAL
#### TODOS and Open Questions
 [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
