### PR TITLE
UISACQCOMP-160 lock react-virtualized-auto-sizer to 1.0.7

### DIFF
--- a/.github/workflows/build-npm-release.yml
+++ b/.github/workflows/build-npm-release.yml
@@ -28,7 +28,7 @@ jobs:
       FOLIO_NPM_REGISTRY: 'https://repository.folio.org/repository/npm-folio/'
       FOLIO_NPM_REGISTRY_AUTH: '//repository.folio.org/repository/npm-folio/'
       FOLIO_MD_REGISTRY: 'https://folio-registry.dev.folio.org'
-      NODEJS_VERSION: '16'
+      NODEJS_VERSION: '18'
       JEST_JUNIT_OUTPUT_DIR: 'artifacts/jest-junit'
       JEST_COVERAGE_REPORT_DIR: 'artifacts/coverage-jest/lcov-report/'
       BIGTEST_JUNIT_OUTPUT_DIR: 'artifacts/runTest'
@@ -243,4 +243,3 @@ jobs:
           data: ${{ steps.moduleDescriptor.outputs.content }}
           username: ${{ secrets.FOLIO_REGISTRY_USERNAME }}
           password: ${{ secrets.FOLIO_REGISTRY_PASSWORD }}
-

--- a/.github/workflows/build-npm.yml
+++ b/.github/workflows/build-npm.yml
@@ -25,7 +25,7 @@ jobs:
       FOLIO_NPM_REGISTRY: 'https://repository.folio.org/repository/npm-folioci/'
       FOLIO_NPM_REGISTRY_AUTH: '//repository.folio.org/repository/npm-folioci/'
       FOLIO_MD_REGISTRY: 'https://folio-registry.dev.folio.org'
-      NODEJS_VERSION: '16'
+      NODEJS_VERSION: '18'
       JEST_JUNIT_OUTPUT_DIR: 'artifacts/jest-junit'
       JEST_COVERAGE_REPORT_DIR: 'artifacts/coverage-jest/lcov-report/'
       BIGTEST_JUNIT_OUTPUT_DIR: 'artifacts/runTest'
@@ -196,4 +196,3 @@ jobs:
           data: ${{ steps.moduleDescriptor.outputs.content }}
           username: ${{ secrets.FOLIO_REGISTRY_USERNAME }}
           password: ${{ secrets.FOLIO_REGISTRY_PASSWORD }}
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change history for stripes-acq-components
 
-## (4.1.0 IN PROGRESS)
+## 4.0.3 IN PROGRESS
+
+* Lock `react-virtual-auto-sizer` to `1.0.7` to preserve `<Pane>` CSS behavior. Refs UISACQCOMP-160.
 
 ## [4.0.2](https://github.com/folio-org/stripes-acq-components/tree/v4.0.2) (2023-03-17)
 [Full Changelog](https://github.com/folio-org/stripes-acq-components/compare/v4.0.1...v4.0.2)

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "react-dropzone": "^10.0.0",
     "react-final-form": "^6.3.0",
     "react-final-form-arrays": "^3.1.1",
-    "react-virtualized-auto-sizer": "^1.0.6",
+    "react-virtualized-auto-sizer": "1.0.7",
     "redux-form": "^8.3.0"
   },
   "peerDependencies": {

--- a/test/jest/babel.config.js
+++ b/test/jest/babel.config.js
@@ -7,8 +7,8 @@ module.exports = {
   'plugins': [
     ['@babel/plugin-proposal-decorators', { 'legacy': true }],
     ['@babel/plugin-proposal-class-properties', { 'loose': true }],
-    ['@babel/plugin-proposal-private-methods', { 'loose': true }],
-    ['@babel/plugin-proposal-private-property-in-object', { 'loose': true }],
+    ['@babel/plugin-transform-private-methods', { 'loose': true }],
+    ['@babel/plugin-transform-private-property-in-object', { 'loose': true }],
     '@babel/plugin-transform-runtime',
   ],
 };


### PR DESCRIPTION
Lock `react-virtualized-auto-sizer` to `v1.0.7` to preserve the CSS behavior of `<Pane>` related to the "Actions" menu. RVAS >= `v1.0.8` substantially reworked its internal structure, changing the way it interacts with `<Pane>`, a bug described in detail in STCOM-1148.

Avoiding the update or changing our CSS are both viable approaches to resolving the problem. Given stripes-components already takes the former approach in its Orchid-compatible release (`v11.0.4`).

Refs [UISACQCOMP-160](https://issues.folio.org/browse/UISACQCOMP-160), [STCOM-1148](https://issues.folio.org/browse/STCOM-1148), [STCOM-1146](https://issues.folio.org/browse/STCOM-1146)
