### PR TITLE
UISACQCOMP-164 Add inputType prop to <SingleSearchForm> to make Inventory Browse search box a textarea

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## (5.1.0 IN PROGRESS)
 
 * Sort the list of countries based on the current locale. Refs UISACQCOMP-164.
+* Add `inputType` prop to `<SingleSearchForm>`. Refs UISACQCOMP-165.
 
 ## [5.0.0](https://github.com/folio-org/stripes-acq-components/tree/v5.0.0) (2023-10-12)
 [Full Changelog](https://github.com/folio-org/stripes-acq-components/compare/v4.0.2...v5.0.0)

--- a/lib/AcqList/SingleSearchForm/SingleSearchForm.js
+++ b/lib/AcqList/SingleSearchForm/SingleSearchForm.js
@@ -30,6 +30,7 @@ const SingleSearchForm = ({
   selectedIndex,
   changeSearchIndex,
   searchableOptions,
+  inputType,
 }) => {
   const [translatedSearchableIndexes, setTranslatedSearchableIndexes] = useState();
   const intl = useIntl();
@@ -96,6 +97,10 @@ const SingleSearchForm = ({
         searchableOptions={searchableOptions}
         searchableIndexesPlaceholder={searchableIndexesPlaceholder}
         selectedIndex={selectedIndex}
+        inputType={inputType}
+        lockWidth
+        newLineOnShiftEnter
+        onSubmitSearch={submitSearch}
       />
 
       <Button
@@ -135,6 +140,7 @@ SingleSearchForm.propTypes = {
   ]),
   selectedIndex: PropTypes.string,
   changeSearchIndex: PropTypes.func,
+  inputType: PropTypes.string,
 };
 
 SingleSearchForm.defaultProps = {


### PR DESCRIPTION
## Description
Add inputType prop to <SingleSearchForm>

## Screenshots
![image](https://github.com/folio-org/stripes-acq-components/assets/19309423/1b5e1441-56c0-43a4-baad-f8f0c5230214)


## Issues
[UISACQCOMP-165](https://issues.folio.org/browse/UISACQCOMP-165)