### PR TITLE
UISACQCOMP-167 Added `indexRef` and `inputRef` props to `<SingleSearchForm>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Sort the list of countries based on the current locale. Refs UISACQCOMP-164.
 * Add `inputType` prop to `<SingleSearchForm>`. Refs UISACQCOMP-165.
 * View the list of donors. Refs UISACQCOMP-166.
+* Added `indexRef` and `inputRef` props to `<SingleSearchForm>`. Refs UISACQCOMP-167.
 
 ## [5.0.0](https://github.com/folio-org/stripes-acq-components/tree/v5.0.0) (2023-10-12)
 [Full Changelog](https://github.com/folio-org/stripes-acq-components/compare/v4.0.2...v5.0.0)

--- a/lib/AcqList/SingleSearchForm/SingleSearchForm.js
+++ b/lib/AcqList/SingleSearchForm/SingleSearchForm.js
@@ -31,6 +31,8 @@ const SingleSearchForm = ({
   changeSearchIndex,
   searchableOptions,
   inputType,
+  indexRef,
+  inputRef,
 }) => {
   const [translatedSearchableIndexes, setTranslatedSearchableIndexes] = useState();
   const intl = useIntl();
@@ -97,6 +99,8 @@ const SingleSearchForm = ({
         searchableOptions={searchableOptions}
         searchableIndexesPlaceholder={searchableIndexesPlaceholder}
         selectedIndex={selectedIndex}
+        indexRef={indexRef}
+        inputRef={inputRef}
         inputType={inputType}
         lockWidth
         newLineOnShiftEnter
@@ -141,6 +145,14 @@ SingleSearchForm.propTypes = {
   selectedIndex: PropTypes.string,
   changeSearchIndex: PropTypes.func,
   inputType: PropTypes.string,
+  indexRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+  ]),
+  inputRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+  ]),
 };
 
 SingleSearchForm.defaultProps = {


### PR DESCRIPTION
## Description
Added `indexRef` and `inputRef` props to `<SingleSearchForm>`

## Issues
[UISACQCOMP-167](https://issues.folio.org/browse/UISACQCOMP-167)

## Related PRs
https://github.com/folio-org/stripes-components/pull/2169
https://github.com/folio-org/ui-inventory/pull/2335