### PR TITLE
UISACQCOMP-172: remove unused console log statement

### DIFF
--- a/lib/PrivilegedDonorContacts/PrivilegedDonorContactsLookup.js
+++ b/lib/PrivilegedDonorContacts/PrivilegedDonorContactsLookup.js
@@ -12,16 +12,12 @@ import { PRIVILEGED_CONTACT_URL } from './constants';
 export const PrivilegedDonorContactsLookup = ({
   onAddContacts,
   orgId,
-  searchButtonStyle: searchButtonStyleProp,
+  searchButtonStyle,
   searchLabel,
 }) => {
   const stripes = useStripes();
 
   const canAddContact = stripes.hasPerm('ui-organizations.privileged-contacts.edit');
-  const searchButtonStyle = canAddContact ? searchButtonStyleProp : 'disabled';
-
-  console.log('searchButtonStyle', { searchButtonStyle, canAddContact });
-
   const renderNewContactBtn = () => {
     const url = `/organizations${orgId ? '/' + orgId : ''}/${PRIVILEGED_CONTACT_URL}/add-contact`;
 
@@ -48,6 +44,7 @@ export const PrivilegedDonorContactsLookup = ({
       addContacts={onAddContacts}
       renderNewContactBtn={renderNewContactBtn}
       isPrivilegedContactEnabled
+      disabled={!canAddContact}
     >
       <span data-test-add-contact>
         <FormattedMessage id="stripes-acq-components.privilegedContacts.noFindContactPlugin" />

--- a/lib/PrivilegedDonorContacts/PrivilegedDonorContactsLookup.test.js
+++ b/lib/PrivilegedDonorContacts/PrivilegedDonorContactsLookup.test.js
@@ -9,14 +9,14 @@ const mockContactData = { id: '1', name: 'Amazon' };
 
 jest.mock('@folio/stripes/core', () => ({
   ...jest.requireActual('@folio/stripes/core'),
-  Pluggable: jest.fn(({ children, searchButtonStyle, ...rest }) => {
+  Pluggable: jest.fn(({ children, disabled, ...rest }) => {
     return (
       <div>
         {children}
         <button
           type="button"
           id={rest?.name}
-          disabled={searchButtonStyle === 'disabled'}
+          disabled={disabled}
           onClick={() => rest?.addContacts([mockContactData])}
         >
           Add donor


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
[UISACQCOMP-172](https://issues.folio.org/browse/UISACQCOMP-172) - disable add donor button if user doesn't have permission to create privileged donor contacts
## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

https://github.com/folio-org/stripes-acq-components/assets/116072773/b2554890-86a9-4b41-b224-ffdac9608da1


<!-- OPTIONAL
#### TODOS and Open Questions
 [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
