### PR TITLE
[UISACQCOMP-175] Add missing stripes-types dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "redux": "^4.0.5"
   },
   "dependencies": {
+    "@folio/stripes-types": "^2.1.0",
     "@rehooks/local-storage": "^2.4.4",
     "classnames": "^2.2.5",
     "dom-helpers": "^3.4.0",


### PR DESCRIPTION
In #745 , we forgot to add `1@folio/stripes-types` as a dependency. This adds this missing dependency.