### PR TITLE
UISACQCOMP-181 Added new returned `clearLocationFilters` function from `useLocationFilters`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## (5.2.0 IN PROGRESS)
 
+* Added new returned `clearLocationFilters` function from `useLocationFilters`. Refs UISACQCOMP-181.
+
 ## [5.1.0](https://github.com/folio-org/stripes-acq-components/tree/v5.1.0) (2024-03-18)
 [Full Changelog](https://github.com/folio-org/stripes-acq-components/compare/v5.0.0...v5.1.0)
 

--- a/lib/AcqList/hooks/useLocationFilters.js
+++ b/lib/AcqList/hooks/useLocationFilters.js
@@ -2,7 +2,6 @@ import {
   useEffect,
   useCallback,
 } from 'react';
-import queryString from 'query-string';
 import pick from 'lodash/pick';
 
 import {
@@ -92,15 +91,10 @@ const useLocationFilters = (location, history, resetData) => {
         const newFilters = pick(currentFilters, ['qindex', 'query']);
 
         return newFilters;
-      }, (curState) => {
-        resetData();
-
-        history.push({
-          search: queryString.stringify(curState),
-        });
       });
+      resetData();
     },
-    [history, setFilters, resetData],
+    [setFilters, resetData],
   );
 
   const changeLocationSearchIndex = useCallback(

--- a/lib/AcqList/hooks/useLocationFilters.js
+++ b/lib/AcqList/hooks/useLocationFilters.js
@@ -2,6 +2,8 @@ import {
   useEffect,
   useCallback,
 } from 'react';
+import queryString from 'query-string';
+import pick from 'lodash/pick';
 
 import {
   SEARCH_INDEX_PARAMETER,
@@ -80,6 +82,27 @@ const useLocationFilters = (location, history, resetData) => {
     [history, resetFilters],
   );
 
+  const clearLocationFilters = useCallback(
+    () => {
+      /*
+        there's a lot of state setters called synchronously both in this hook and it's consumers
+        so we need to be careful about not using old state data
+      */
+      setFilters((currentFilters) => {
+        const newFilters = pick(currentFilters, ['qindex', 'query']);
+
+        return newFilters;
+      }, (curState) => {
+        resetData();
+
+        history.push({
+          search: queryString.stringify(curState),
+        });
+      });
+    },
+    [history, setFilters, resetData],
+  );
+
   const changeLocationSearchIndex = useCallback(
     (e) => {
       changeSearchIndex(e);
@@ -96,6 +119,7 @@ const useLocationFilters = (location, history, resetData) => {
     resetLocationFilters,
     changeLocationSearchIndex,
     searchIndex,
+    clearLocationFilters,
   ];
 };
 

--- a/lib/AcqList/hooks/useLocationFilters.test.js
+++ b/lib/AcqList/hooks/useLocationFilters.test.js
@@ -1,0 +1,130 @@
+import React from 'react';
+import {
+  fireEvent,
+  render,
+  cleanup,
+  waitFor,
+} from '@testing-library/react';
+import {
+  MemoryRouter,
+  Route,
+} from 'react-router-dom';
+import { withRouter } from 'react-router';
+import {
+  deleteFromStorage,
+  useLocalStorage,
+  writeStorage,
+} from '@rehooks/local-storage';
+
+import useLocationFilters from './useLocationFilters';
+
+const mockResetData = jest.fn();
+
+const TestList = withRouter(({ location, history }) => {
+  const [
+    // eslint-disable-next-line no-unused-vars
+    filters,
+    searchQuery,
+    applyFilters,
+    applySearch,
+    changeSearch,
+    resetFilters,
+    // eslint-disable-next-line no-unused-vars
+    changeIndex,
+    searchIndex,
+    clearLocationFilters,
+  ] = useLocationFilters(location, history, mockResetData);
+
+  return (
+    <>
+      <div data-testid="search-query">{searchQuery}</div>
+      <div data-testid="search-index">{searchIndex}</div>
+      <input
+        data-testid="search-query-input"
+        type="text"
+        value={searchQuery}
+        onChange={changeSearch}
+      />
+      <input
+        data-testid="filter1"
+        name="Filter 1"
+        onChange={() => applyFilters('Filter 1', ['true'])}
+        type="checkbox"
+      />
+      <button
+        type="button"
+        onClick={applySearch}
+      >
+        Search
+      </button>
+      <button
+        type="button"
+        onClick={resetFilters}
+      >
+        Reset
+      </button>
+      <button
+        type="button"
+        onClick={clearLocationFilters}
+      >
+        Clear filters
+      </button>
+    </>
+  );
+});
+
+const renderTestList = (initialRoute = '/some-route') => render(
+  <MemoryRouter initialEntries={[initialRoute]}>
+    <Route
+      component={TestList}
+    />
+  </MemoryRouter>,
+);
+
+describe('useLocationFilters', () => {
+  beforeEach(() => {
+    useLocalStorage.mockClear().mockReturnValue([]);
+    writeStorage.mockClear();
+    deleteFromStorage.mockClear();
+    mockResetData.mockClear();
+  });
+
+  afterEach(cleanup);
+
+  it('should set searchQuery from location.search', () => {
+    const { getByTestId } = renderTestList('/some-route?query=testquery');
+
+    expect(getByTestId('search-query').textContent).toBe('testquery');
+  });
+
+  describe('when calling clearLocationFilters', () => {
+    it('should clear filters and keep qindex and query', async () => {
+      const {
+        getByTestId,
+        getByText,
+      } = renderTestList('/some-route?query=testquery&qindex=testindex&Filter%201=true');
+
+      fireEvent.click(getByText('Clear filters'));
+
+      expect(getByTestId('search-query').textContent).toBe('testquery');
+      expect(getByTestId('search-index').textContent).toBe('testindex');
+      expect(getByTestId('filter1')).not.toBeChecked();
+      await waitFor(() => expect(mockResetData).toHaveBeenCalled());
+    });
+  });
+
+  describe('when calling resetLocationFilters', () => {
+    it('should clear filters, qindex and query', () => {
+      const {
+        getByTestId,
+        getByText,
+      } = renderTestList('/some-route?query=testquery&qindex=testindex&Filter%201=true');
+
+      fireEvent.click(getByText('Reset'));
+
+      expect(getByTestId('search-query').textContent).toBe('');
+      expect(getByTestId('search-index').textContent).toBe('');
+      expect(getByTestId('filter1')).not.toBeChecked();
+    });
+  });
+});

--- a/lib/AcqList/hooks/useLocationFilters.test.js
+++ b/lib/AcqList/hooks/useLocationFilters.test.js
@@ -3,7 +3,6 @@ import {
   fireEvent,
   render,
   cleanup,
-  waitFor,
 } from '@testing-library/react';
 import {
   MemoryRouter,
@@ -98,7 +97,7 @@ describe('useLocationFilters', () => {
   });
 
   describe('when calling clearLocationFilters', () => {
-    it('should clear filters and keep qindex and query', async () => {
+    it('should clear filters and keep qindex and query', () => {
       const {
         getByTestId,
         getByText,
@@ -109,7 +108,6 @@ describe('useLocationFilters', () => {
       expect(getByTestId('search-query').textContent).toBe('testquery');
       expect(getByTestId('search-index').textContent).toBe('testindex');
       expect(getByTestId('filter1')).not.toBeChecked();
-      await waitFor(() => expect(mockResetData).toHaveBeenCalled());
     });
   });
 


### PR DESCRIPTION
## Description
Added new returned `clearLocationFilters` function from `useLocationFilters`

`useLocationFilters`’s `resetLocationFilters` function clears filters and query and qindex

In Inventory Browse we need to clear only filters when user selects different browse options

## Screenshots

https://github.com/folio-org/stripes-acq-components/assets/19309423/fe310178-e687-4df0-9275-a46703b79ec0



## Issues
[UISACQCOMP-181](https://folio-org.atlassian.net/browse/UISACQCOMP-181)