### PR TITLE
Add <CustomFieldsFilters> and <CustomFieldFilter> components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Added new returned `clearLocationFilters` function from `useLocationFilters`. Refs UISACQCOMP-181.
 * Implement common tools to retrieve "Central ordering" settings. Refs UISACQCOMP-182.
+* Add `<CustomFieldsFilters>` and `<CustomFieldsFilter>` components. Refs UISACQCOMP-183.
 
 ## [5.1.0](https://github.com/folio-org/stripes-acq-components/tree/v5.1.0) (2024-03-18)
 [Full Changelog](https://github.com/folio-org/stripes-acq-components/compare/v5.0.0...v5.1.0)

--- a/jest.config.js
+++ b/jest.config.js
@@ -17,8 +17,7 @@ module.exports = {
   },
   transformIgnorePatterns: [`/node_modules/(?!${esModules})`],
   moduleNameMapper: {
-    '^.+\\.(css)$': 'identity-obj-proxy',
-    '^.+\\.(svg)$': 'identity-obj-proxy',
+    '^.+\\.(css|svg|png)$': 'identity-obj-proxy',
   },
   testMatch: ['**/(lib|src)/**/?(*.)test.{js,jsx}'],
   testPathIgnorePatterns: ['/node_modules/', '/test/ui-testing/', '/test/bigtest/'],

--- a/lib/CustomFieldsFilters/CustomFieldsFilter.js
+++ b/lib/CustomFieldsFilters/CustomFieldsFilter.js
@@ -1,0 +1,95 @@
+import PropTypes from 'prop-types';
+import { memo } from 'react';
+import { useIntl } from 'react-intl';
+
+import {
+  CheckboxFilter,
+  MultiSelectionFilter,
+} from '@folio/stripes/smart-components';
+
+import { AcqDateRangeFilter } from '../AcqDateRangeFilter';
+import { CUSTOM_FIELDS } from '../constants';
+import { FilterAccordion } from '../FilterAccordion';
+
+// Map custom field types to specific filters
+const customFieldTypeToFilterMap = {
+  DATE_PICKER: AcqDateRangeFilter,
+  MULTI_SELECT_DROPDOWN: MultiSelectionFilter,
+  RADIO_BUTTON: CheckboxFilter,
+  SINGLE_CHECKBOX: CheckboxFilter,
+  SINGLE_SELECT_DROPDOWN: MultiSelectionFilter,
+};
+
+const CustomFieldsFilter = ({
+  activeFilters,
+  closedByDefault,
+  customField,
+  disabled,
+  onChange,
+}) => {
+  const FilterComponent = customFieldTypeToFilterMap[customField.type];
+  const { refId, name, selectField } = customField;
+  const values = selectField?.options?.values ?? [{ id: 'true', value: name }];
+  const filterName = `${CUSTOM_FIELDS}.${refId}`;
+  const dataOptions = values.map(({ id: value, value: label }) => ({
+    label,
+    value,
+  }));
+
+  const intl = useIntl();
+
+  const customFieldLabel = intl.formatMessage({ id: 'stripes-smart-components.customFields' });
+  const fieldLabel = `${customFieldLabel} ${name}`;
+
+  if (!FilterComponent) {
+    return null;
+  }
+
+  if (FilterComponent === AcqDateRangeFilter) {
+    return (
+      <AcqDateRangeFilter
+        activeFilters={activeFilters}
+        disabled={disabled}
+        id={filterName}
+        labelId={fieldLabel}
+        name={filterName}
+        onChange={onChange}
+      />
+    );
+  }
+
+  return (
+    <FilterAccordion
+      activeFilters={activeFilters}
+      closedByDefault={closedByDefault}
+      disabled={disabled}
+      id={filterName}
+      labelId={fieldLabel}
+      name={filterName}
+      onChange={onChange}
+    >
+      <FilterComponent
+        dataOptions={dataOptions}
+        disabled={disabled}
+        name={filterName}
+        selectedValues={activeFilters}
+        onChange={onChange}
+      />
+    </FilterAccordion>
+  );
+};
+
+CustomFieldsFilter.propTypes = {
+  activeFilters: PropTypes.arrayOf(PropTypes.string),
+  closedByDefault: PropTypes.bool,
+  customField: PropTypes.object,
+  disabled: PropTypes.bool,
+  onChange: PropTypes.func.isRequired,
+};
+
+CustomFieldsFilter.defaultProps = {
+  closedByDefault: true,
+  disabled: false,
+};
+
+export default memo(CustomFieldsFilter);

--- a/lib/CustomFieldsFilters/CustomFieldsFilter.test.js
+++ b/lib/CustomFieldsFilters/CustomFieldsFilter.test.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 
 import { CUSTOM_FIELDS } from '../../test/jest/fixtures/customFields';

--- a/lib/CustomFieldsFilters/CustomFieldsFilter.test.js
+++ b/lib/CustomFieldsFilters/CustomFieldsFilter.test.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { CUSTOM_FIELDS } from '../../test/jest/fixtures/customFields';
+import CustomFieldsFilter from './CustomFieldsFilter';
+
+const onChange = jest.fn();
+
+const renderCustomFieldsFilter = (cf) => render(
+  <CustomFieldsFilter customField={cf} onChange={onChange} />,
+);
+
+describe('CustomFieldsFilter', () => {
+  it('should display Multiselect filter', () => {
+    const multiselect = CUSTOM_FIELDS.find((cf) => cf.refId === 'multiselect');
+
+    renderCustomFieldsFilter(multiselect);
+    expect(screen.getByText('Multiselect')).toBeDefined();
+  });
+
+  it('should display Singleselect filter', () => {
+    const singleselect = CUSTOM_FIELDS.find((cf) => cf.refId === 'singleselect');
+
+    renderCustomFieldsFilter(singleselect);
+    expect(screen.getByText('Singleselect')).toBeDefined();
+  });
+
+  it('should display Datepicker filter', () => {
+    const datepicker = CUSTOM_FIELDS.find((cf) => cf.refId === 'datepicker');
+
+    renderCustomFieldsFilter(datepicker);
+    expect(screen.getByText('stripes-smart-components.customFields Datepicker')).toBeDefined();
+  });
+
+  it('should not display filter with undefined type', () => {
+    const { container } = renderCustomFieldsFilter({ type: 'UNDEFINED_TYPE' });
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/lib/CustomFieldsFilters/CustomFieldsFilters.js
+++ b/lib/CustomFieldsFilters/CustomFieldsFilters.js
@@ -1,0 +1,31 @@
+import PropTypes from 'prop-types';
+
+import { CUSTOM_FIELDS } from '../constants';
+import CustomFieldsFilter from './CustomFieldsFilter';
+
+export const CustomFieldsFilters = ({
+  activeFilters,
+  customFields,
+  onChange,
+  ...props
+}) => {
+  if (!customFields) return null;
+
+  return customFields.map((customField) => (
+    <CustomFieldsFilter
+      activeFilters={activeFilters[`${CUSTOM_FIELDS}.${customField.refId}`]}
+      customField={customField}
+      key={`custom-field-${customField.id}`}
+      onChange={onChange}
+      {...props}
+    />
+  ));
+};
+
+CustomFieldsFilters.propTypes = {
+  activeFilters: PropTypes.object,
+  closedByDefault: PropTypes.bool,
+  customFields: PropTypes.arrayOf(PropTypes.object),
+  disabled: PropTypes.bool,
+  onChange: PropTypes.func.isRequired,
+};

--- a/lib/CustomFieldsFilters/CustomFieldsFilters.test.js
+++ b/lib/CustomFieldsFilters/CustomFieldsFilters.test.js
@@ -1,0 +1,38 @@
+import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+
+import { CUSTOM_FIELDS } from '../../test/jest/fixtures/customFields';
+import { CustomFieldsFilters } from './CustomFieldsFilters';
+
+jest.mock('./CustomFieldsFilter', () => jest.fn(() => <div>CustomFieldsFilter</div>));
+
+const onChange = jest.fn();
+
+const activeFilters = {};
+
+const renderCustomFieldsFilters = (cf) => render(
+  <CustomFieldsFilters
+    activeFilters={activeFilters}
+    customFields={cf}
+    onChange={onChange}
+  />,
+);
+
+describe('CustomFieldsFilters', () => {
+  it('should be rendered for each element in customFields', () => {
+    renderCustomFieldsFilters(CUSTOM_FIELDS);
+
+    const customFieldsFilters = screen.queryAllByText('CustomFieldsFilter');
+
+    expect(customFieldsFilters).toHaveLength(CUSTOM_FIELDS.length);
+  });
+
+  it('should not be rendered if customFields is undefined', () => {
+    renderCustomFieldsFilters();
+
+    const customFieldsFilters = screen.queryByText('CustomFieldsFilter');
+
+    expect(customFieldsFilters).toBeNull();
+  });
+});

--- a/lib/CustomFieldsFilters/CustomFieldsFilters.test.js
+++ b/lib/CustomFieldsFilters/CustomFieldsFilters.test.js
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { render, screen } from '@testing-library/react';
 
 import { CUSTOM_FIELDS } from '../../test/jest/fixtures/customFields';

--- a/lib/CustomFieldsFilters/README.md
+++ b/lib/CustomFieldsFilters/README.md
@@ -1,0 +1,40 @@
+# CustomFieldsFilters
+
+Renders a set of filter components based on the provided custom fields data.
+Each filter component gets rendered inside a `<FilterAccordion>`. Depending on
+the type of the custom field different filter components are rendered:
+
+| Custom field type | Component
+--- | ---
+DATE_PICKER | `<AcqDateRangeFilter>`
+MULTI_SELECT_DROPDOWN | `<MultiSelectionFilter>`
+RADIO_BUTTON | `<CheckboxFilter>`
+SINGLE_CHECKBOX | `<CheckboxFilter>`
+SINGLE_SELECT_DROPDOWN | `<MultiSelectionFilter>`
+
+## Usage example
+
+Include `<CustomFieldsFilters>` to your filter section. See  [ui-orders](https://github.com/folio-org/ui-orders/blob/master/src/OrdersList/OrdersListFilters.js). 
+
+```js
+<AccordionSet>
+  ...
+  <CustomFieldsFilters
+    activeFilters={activeFilters}
+    customFields={customFields}
+    onChange={onChange}
+  />
+  ...
+</AccordionSet>
+```
+
+
+## Props
+
+Name | Type | Description | Required
+--- | --- | --- | ---
+`activeFilters` | object | An object containing the active filter values. Each key corresponds to a specific custom field (e.g. `customFields.date1`) and the value represents the filter value for that field. | false
+`closedByDefault` | bool | Determines whether the filter accordions are closed by default. | false
+`customFields` | array | An array of custom field objects. | false
+`disabled` | bool | Determines whether the filter components are disabled. | false
+`onChange` | func | A callback function that is invoked when a filter value is changed. | true

--- a/lib/CustomFieldsFilters/index.js
+++ b/lib/CustomFieldsFilters/index.js
@@ -1,0 +1,1 @@
+export { CustomFieldsFilters } from './CustomFieldsFilters';

--- a/lib/constants/constants.js
+++ b/lib/constants/constants.js
@@ -20,3 +20,5 @@ export const DICT_IDENTIFIER_TYPES = 'identifierTypes';
 export const DICT_CONTRIBUTOR_NAME_TYPES = 'contributorNameTypes';
 
 export const emptyArrayFilterValue = '/respectAccents []';
+
+export const CUSTOM_FIELDS = 'customFields';

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,6 +15,7 @@ export * from './CountryFilter';
 export * from './Currency';
 export * from './CurrencyExchangeRateFields';
 export * from './CurrencySymbol';
+export * from './CustomFieldsFilters';
 export * from './DeleteHoldingsModal';
 export * from './Donors';
 export * from './DonorsFilter';

--- a/test/jest/fixtures/customFields.js
+++ b/test/jest/fixtures/customFields.js
@@ -1,0 +1,32 @@
+export const CUSTOM_FIELDS = [
+  {
+    'id': 'bb9bae41-cb8b-430f-8912-616415294cce',
+    'type': 'DATE_PICKER',
+    'name': 'Datepicker',
+    'refId': 'datepicker',
+  },
+  {
+    'id': '6ce5cc69-9ca8-4024-9bd4-65c4e5927dfe',
+    'type': 'TEXTBOX_SHORT',
+    'name': 'Long text',
+    'refId': 'longtext',
+  },
+  {
+    'id': '6cd18404-a21a-4dd9-80ce-c3fa463fdf95',
+    'type': 'TEXTBOX_LONG',
+    'name': 'Short text',
+    'refId': 'shorttext',
+  },
+  {
+    'id': '98da725c-7f07-48e1-b15b-4b53065f67d7',
+    'type': 'MULTI_SELECT_DROPDOWN',
+    'name': 'Multiselect',
+    'refId': 'multiselect',
+  },
+  {
+    'id': '2bd9a821-d550-40b0-81f9-71ad28fe2922',
+    'type': 'SINGLE_SELECT_DROPDOWN',
+    'name': 'Singleselect',
+    'refId': 'singleselect',
+  },
+];


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UISACQCOMP-183

## Purpose
Relocate `<CustomFieldsFilters>` and `<CustomFieldsFilter>` from [`ui-orders`](https://github.com/folio-org/ui-orders/tree/bc6c6da572aecd47c787d8c8f2d0e2d57abcc1a2/src/common/CustomFieldsFilters) to enable their reuse in other applications.
