### PR TITLE
UISACQCOMP-182 Send requests only in the central tenant in the `useCentralOrderingSettings` hook

### DIFF
--- a/lib/hooks/useCentralOrderingSettings/useCentralOrderingSettings.js
+++ b/lib/hooks/useCentralOrderingSettings/useCentralOrderingSettings.js
@@ -3,6 +3,7 @@ import { useQuery } from 'react-query';
 import {
   useNamespace,
   useOkapiKy,
+  useStripes,
 } from '@folio/stripes/core';
 
 import {
@@ -11,7 +12,12 @@ import {
 } from '../../constants';
 
 export const useCentralOrderingSettings = (options = {}) => {
-  const ky = useOkapiKy();
+  const stripes = useStripes();
+
+  const centralTenantId = stripes.user?.user?.consortium?.centralTenantId;
+  const { enabled = true, ...restOptions } = options;
+
+  const ky = useOkapiKy({ tenant: centralTenantId });
   const [namespace] = useNamespace('central-ordering-settings');
 
   const searchParams = {
@@ -25,13 +31,14 @@ export const useCentralOrderingSettings = (options = {}) => {
     isLoading,
     refetch,
   } = useQuery({
-    queryKey: [namespace],
+    queryKey: [namespace, centralTenantId],
     queryFn: async () => {
       const response = await ky.get(ORDERS_STORAGE_SETTINGS_API, { searchParams }).json();
 
       return response?.settings?.[0];
     },
-    ...options,
+    enabled: Boolean(enabled && centralTenantId),
+    ...restOptions,
   });
 
   return ({

--- a/lib/hooks/useCentralOrderingSettings/useCentralOrderingSettings.test.js
+++ b/lib/hooks/useCentralOrderingSettings/useCentralOrderingSettings.test.js
@@ -14,6 +14,7 @@ import { useCentralOrderingSettings } from './useCentralOrderingSettings';
 
 jest.mock('@folio/stripes/core', () => ({
   ...jest.requireActual('@folio/stripes/core'),
+  useNamespace: jest.fn(() => (['namespace'])),
   useOkapiKy: jest.fn(),
   useStripes: jest.fn(),
 }));

--- a/lib/hooks/useCentralOrderingSettings/useCentralOrderingSettings.test.js
+++ b/lib/hooks/useCentralOrderingSettings/useCentralOrderingSettings.test.js
@@ -4,10 +4,19 @@ import {
   QueryClientProvider,
 } from 'react-query';
 
-import { useOkapiKy } from '@folio/stripes/core';
+import {
+  useOkapiKy,
+  useStripes,
+} from '@folio/stripes/core';
 
 import { CENTRAL_ORDERING_SETTINGS_KEY } from '../../constants';
 import { useCentralOrderingSettings } from './useCentralOrderingSettings';
+
+jest.mock('@folio/stripes/core', () => ({
+  ...jest.requireActual('@folio/stripes/core'),
+  useOkapiKy: jest.fn(),
+  useStripes: jest.fn(),
+}));
 
 const queryClient = new QueryClient();
 const wrapper = ({ children }) => (
@@ -22,6 +31,16 @@ const mockData = {
   value: 'true',
 };
 
+const stripesMock = {
+  user: {
+    user: {
+      consortium: {
+        centralTenantId: 'centralTenantId',
+      },
+    },
+  },
+};
+
 describe('useCentralOrderingSettings', () => {
   beforeEach(() => {
     useOkapiKy
@@ -31,6 +50,9 @@ describe('useCentralOrderingSettings', () => {
           json: () => Promise.resolve({ settings: [mockData] }),
         }),
       });
+    useStripes
+      .mockClear()
+      .mockReturnValue(stripesMock);
   });
 
   it('should fetch central ordering settings', async () => {


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://folio-org.atlassian.net/browse/UISACQCOMP-182

The central ordering setting stored only in the central tenant of a consortium, so we have to check this setting there even a user is currently in the member tenant.

Original PR #764 
## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

<!-- OPTIONAL
#### TODOS and Open Questions
 [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->
Set central tenant as a `tenant` prop for the `useOkapyKy` hook.
<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
