### PR TITLE
UISACQCOMP-189 Correctly manage state setting in the 'toggle' function of the 'useToggle' hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@
 * Add `<CustomFieldsFilters>` and `<CustomFieldsFilter>` components. Refs UISACQCOMP-183.
 * Create `<RoutingList>` component for Routing list table. Refs UISACQCOMP-184.
 * Add functions related to custom fields filter and search functionality. Refs UISACQCOMP-186.
-* *BREAKING* ECS - Support for location search in the context of multiple consortium affiliations. UISACQCOMP-185.
-* *BREAKING* ECS - Adjust the locations filter to support cross-tenant search mode. UISACQCOMP-187.
+* *BREAKING* ECS - Support for location search in the context of multiple consortium affiliations. Refs UISACQCOMP-185.
+* *BREAKING* ECS - Adjust the locations filter to support cross-tenant search mode. Refs UISACQCOMP-187.
+* Correctly manage state setting in the `toggle` function of the `useToggle` hook. Refs UISACQCOMP-189.
 
 ## [5.1.1](https://github.com/folio-org/stripes-acq-components/tree/v5.1.1) (2024-04-22)
 [Full Changelog](https://github.com/folio-org/stripes-acq-components/compare/v5.1.0...v5.1.1)

--- a/lib/hooks/useToggle/useToggle.js
+++ b/lib/hooks/useToggle/useToggle.js
@@ -3,7 +3,7 @@ import { useCallback, useState } from 'react';
 export const useToggle = (defaultState) => {
   const [isOpen, setIsOpen] = useState(defaultState);
 
-  const toggle = useCallback(() => setIsOpen(!isOpen), [isOpen]);
+  const toggle = useCallback(() => setIsOpen((prevState) => !prevState), []);
 
   return [isOpen, toggle];
 };


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://folio-org.atlassian.net/browse/UISACQCOMP-189

The state value returned by the `useState` hook only changes after a re-render, so the `toggle` function could recieve the "old state" instead of the current state, causing unexpected results. Therefore, to set a new state based on the previous one, we should use the state update function.

React docs:
- https://react.dev/reference/react/useState#ive-updated-the-state-but-logging-gives-me-the-old-value
- https://react.dev/learn/state-as-a-snapshot#state-over-time

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
Use [state updater function](https://react.dev/learn/queueing-a-series-of-state-updates) to "toggle" the current state.
<!-- OPTIONAL
#### TODOS and Open Questions
 [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
