### PR TITLE
UISACQCOMP-198: *BREAKING* `useFilters` - remove search term trimming.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * ECS - Support affiliations select for the inventory field (`<ConsortiumFieldInventory>`). Refs UISACQCOMP-190.
 * Add Print routing list functionality. Refs UISACQCOMP-191.
 * ECS - Support central ordering in the acq modules. Refs UISACQCOMP-194.
+* *BREAKING* `useFilters` - remove search term trimming. Refs UISACQCOMP-198.
 
 ## [5.1.1](https://github.com/folio-org/stripes-acq-components/tree/v5.1.1) (2024-04-22)
 [Full Changelog](https://github.com/folio-org/stripes-acq-components/compare/v5.1.0...v5.1.1)

--- a/lib/AcqList/hooks/useFilters.js
+++ b/lib/AcqList/hooks/useFilters.js
@@ -38,7 +38,7 @@ const useFilters = (resetData, initialFilters = {}) => {
   );
 
   const changeSearch = useCallback(
-    e => setSearchQuery(e.target.value?.trim()),
+    e => setSearchQuery(e.target.value),
     [],
   );
 

--- a/lib/AcqList/hooks/useFilters.test.js
+++ b/lib/AcqList/hooks/useFilters.test.js
@@ -1,0 +1,23 @@
+import { act } from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+
+import useFilters from './useFilters';
+
+describe('useFilters', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('when changing a search term', () => {
+    it('should not be trimmed to avoid a cursor shift', async () => {
+      const searchTerm = ' test foo ';
+      const event = { target: { value: searchTerm } };
+
+      const { result } = renderHook(useFilters);
+
+      await act(() => result.current.changeSearch(event));
+
+      expect(result.current.searchQuery).toBe(searchTerm);
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-acq-components",
-  "version": "5.1.1",
+  "version": "6.0.0",
   "description": "Component library for Stripes Acquisitions modules",
   "publishConfig": {
     "registry": "https://repository.folio.org/repository/npm-folio/"


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
Prevent a cursor shift when changing a search term.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Description
Currently, removing the first letter moves the cursor to the end of the search term, but should remain in the same place.
Currently: "E K245" -> "K245|"
After the PR is merged: "E K245" -> "| K245"

Remove search term trimming in the `changeSearch` function to fix the cursor shift. However, this is a [breaking change](https://github.com/folio-org/stripes-acq-components/assets/77053927/b0a416d7-3936-4a0f-a125-b24d67d8c765) for Orders. It will be necessary to trim the query before making the fetch in ui-orders and retest this story [UISACQCOMP-76](https://folio-org.atlassian.net/browse/UISACQCOMP-76).

<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

<!-- OPTIONAL
#### TODOS and Open Questions
 [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Issues

[UISACQCOMP-198](https://folio-org.atlassian.net/browse/UISACQCOMP-198)

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.

## Screencast

https://github.com/folio-org/stripes-acq-components/assets/77053927/7135005c-80e9-46e6-bbcc-2c5a7083d2c0



