### PR TITLE
UISACQCOMP-198: Introduce a new flag `skipTrimOnChange` to control the usage of the `trim` function during search change in `useFilters`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Add Print routing list functionality. Refs UISACQCOMP-191.
 * ECS - Support central ordering in the acq modules. Refs UISACQCOMP-194.
 * ECS - Replace calls to the publish coordinator with new endpoints to retrieve locations and their references. Refs UISACQCOMP-199.
+* Introduce a new flag `skipTrimOnChange` to control the usage of the `trim` function during search change in `useFilters`. Refs UISACQCOMP-198.
 
 ## [5.1.1](https://github.com/folio-org/stripes-acq-components/tree/v5.1.1) (2024-04-22)
 [Full Changelog](https://github.com/folio-org/stripes-acq-components/compare/v5.1.0...v5.1.1)

--- a/lib/AcqList/hooks/useFilters.js
+++ b/lib/AcqList/hooks/useFilters.js
@@ -8,10 +8,14 @@ import {
   SEARCH_PARAMETER,
 } from '../constants';
 
-const useFilters = (resetData, initialFilters = {}) => {
+const useFilters = (resetData, initialFilters = {}, options) => {
   const [filters, setFilters] = useState(initialFilters);
   const [searchQuery, setSearchQuery] = useState('');
   const [searchIndex, setSearchIndex] = useState('');
+
+  const {
+    skipTrimOnChange = false,
+  } = options || {};
 
   const applyFilters = useCallback(
     (type, value) => {
@@ -38,8 +42,14 @@ const useFilters = (resetData, initialFilters = {}) => {
   );
 
   const changeSearch = useCallback(
-    e => setSearchQuery(e.target.value?.trim()),
-    [],
+    e => {
+      if (skipTrimOnChange) {
+        setSearchQuery(e.target.value);
+      } else {
+        setSearchQuery(e.target.value?.trim());
+      }
+    },
+    [skipTrimOnChange],
   );
 
   const resetFilters = useCallback(

--- a/lib/AcqList/hooks/useFilters.test.js
+++ b/lib/AcqList/hooks/useFilters.test.js
@@ -1,0 +1,37 @@
+import { act } from 'react';
+import noop from 'lodash/noop';
+
+import { renderHook } from '@testing-library/react-hooks';
+
+import useFilters from './useFilters';
+
+describe('useFilters', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('when changing a search term', () => {
+    it('should trim the search term', async () => {
+      const searchTerm = ' test foo ';
+      const event = { target: { value: searchTerm } };
+
+      const { result } = renderHook(() => useFilters(noop, undefined));
+
+      await act(() => result.current.changeSearch(event));
+
+      expect(result.current.searchQuery).toBe(searchTerm.trim());
+    });
+
+    it('should not trim the search term', async () => {
+      const searchTerm = ' test foo ';
+      const event = { target: { value: searchTerm } };
+      const options = { skipTrimOnChange: true };
+
+      const { result } = renderHook(() => useFilters(noop, undefined, options));
+
+      await act(() => result.current.changeSearch(event));
+
+      expect(result.current.searchQuery).toBe(searchTerm);
+    });
+  });
+});

--- a/lib/AcqList/hooks/useLocationFilters.js
+++ b/lib/AcqList/hooks/useLocationFilters.js
@@ -14,7 +14,7 @@ import {
 } from '../utils';
 import useFilters from './useFilters';
 
-const useLocationFilters = (location, history, resetData) => {
+const useLocationFilters = (location, history, resetData, options) => {
   const {
     filters,
     searchQuery,
@@ -26,7 +26,7 @@ const useLocationFilters = (location, history, resetData) => {
     setSearchIndex,
     searchIndex,
     changeSearchIndex,
-  } = useFilters(resetData);
+  } = useFilters(resetData, undefined, options);
 
   useEffect(
     () => {


### PR DESCRIPTION

<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
Control the usage of the `trim` function during search change in `useFilters`.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Approach
Add a new flag `skipTrimOnChange` .
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

<!-- OPTIONAL
#### TODOS and Open Questions
 [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Issues
[UISACQCOMP-198](https://folio-org.atlassian.net/browse/UISACQCOMP-198)

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
