### PR TITLE
UISACQCOMP-210: Support using custom list of tenants when open the locations modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Keep returnUrl in routing list navigation. Refs UISACQCOMP-206.
 * ECS - clear Location/Holding field when affiliation selected. Refs UISACQCOMP-201.
 * ECS - clear Select location filters on change another Affiliation. Refs UISACQCOMP-208.
+* Support using custom list of tenants when open the locations modal. Refs UISACQCOMP-210.
 
 ## [5.1.1](https://github.com/folio-org/stripes-acq-components/tree/v5.1.1) (2024-04-22)
 [Full Changelog](https://github.com/folio-org/stripes-acq-components/compare/v5.1.0...v5.1.1)

--- a/lib/FindLocation/FindLocationLookup.js
+++ b/lib/FindLocation/FindLocationLookup.js
@@ -8,6 +8,7 @@ import {
   useState,
 } from 'react';
 import { FormattedMessage } from 'react-intl';
+import isEmpty from 'lodash/isEmpty';
 
 import { ColumnManager } from '@folio/stripes/smart-components';
 
@@ -46,6 +47,7 @@ export const FindLocationLookup = (props) => {
     resultsPaneTitle,
     sortableColumns,
     tenantId,
+    customUserTenants = [],
     ...rest
   } = props;
 
@@ -62,12 +64,14 @@ export const FindLocationLookup = (props) => {
   };
 
   const affiliations = useMemo(() => {
-    return currUserTenants?.map(({ id, name, isPrimary }) => ({
+    const userTenants = isEmpty(customUserTenants) ? currUserTenants : customUserTenants;
+
+    return userTenants?.map(({ id, name, isPrimary }) => ({
       tenantId: id,
       tenantName: name,
       isPrimary,
     }));
-  }, [currUserTenants]);
+  }, [currUserTenants, customUserTenants]);
 
   const { institutions, isLoading: isInstitutionsLoading } = useInstitutionsQuery(options);
   const { campuses, isLoading: isCampusesLoading } = useCampusesQuery(options);
@@ -208,6 +212,7 @@ FindLocationLookup.propTypes = {
   sortableColumns: PropTypes.arrayOf(PropTypes.string),
   tenantId: PropTypes.string,
   visibleColumns: PropTypes.arrayOf(PropTypes.string),
+  customUserTenants: PropTypes.arrayOf(PropTypes.object),
 };
 
 FindLocationLookup.defaultProps = {

--- a/lib/FindLocation/FindLocationLookup.js
+++ b/lib/FindLocation/FindLocationLookup.js
@@ -47,7 +47,7 @@ export const FindLocationLookup = (props) => {
     resultsPaneTitle,
     sortableColumns,
     tenantId,
-    customUserTenants = [],
+    tenantsList = [],
     ...rest
   } = props;
 
@@ -64,14 +64,14 @@ export const FindLocationLookup = (props) => {
   };
 
   const affiliations = useMemo(() => {
-    const userTenants = isEmpty(customUserTenants) ? currUserTenants : customUserTenants;
+    const userTenants = isEmpty(tenantsList) ? currUserTenants : tenantsList;
 
     return userTenants?.map(({ id, name, isPrimary }) => ({
       tenantId: id,
       tenantName: name,
       isPrimary,
     }));
-  }, [currUserTenants, customUserTenants]);
+  }, [currUserTenants, tenantsList]);
 
   const { institutions, isLoading: isInstitutionsLoading } = useInstitutionsQuery(options);
   const { campuses, isLoading: isCampusesLoading } = useCampusesQuery(options);
@@ -212,7 +212,7 @@ FindLocationLookup.propTypes = {
   sortableColumns: PropTypes.arrayOf(PropTypes.string),
   tenantId: PropTypes.string,
   visibleColumns: PropTypes.arrayOf(PropTypes.string),
-  customUserTenants: PropTypes.arrayOf(PropTypes.object),
+  tenantsList: PropTypes.arrayOf(PropTypes.object),
 };
 
 FindLocationLookup.defaultProps = {


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
 * Currently we get the list of tenants using `useCurrentUserTenants` hook. But in some cases we need to display all the member tenants except current and central one.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
* Added new prop `customUserTenants`. If it's empty then use tenants from `useCurrentUserTenants` hook.

## Links
[UISACQCOMP-210](https://folio-org.atlassian.net/browse/UISACQCOMP-210)

<!-- OPTIONAL
#### TODOS and Open Questions
 [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
