### PR TITLE
UISACQCOMP-215: ECS - Add `isLoading` prop for holdings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Support using custom list of tenants when open the locations modal. Refs UISACQCOMP-210.
 * ECS - Display all consortium tenants in the affiliation selection of the location lookup. Refs UISACQCOMP-202.
 * Add isMultiSelect prop to DonorsLookup component. Refs UISACQCOMP-212.
+* ECS - Add `isLoading` prop for `ConsortiumFieldInventory` component. Refs UISACQCOMP-215.
 
 ## [5.1.1](https://github.com/folio-org/stripes-acq-components/tree/v5.1.1) (2024-04-22)
 [Full Changelog](https://github.com/folio-org/stripes-acq-components/compare/v5.1.0...v5.1.1)

--- a/lib/ConsortiumFieldInventory/ConsortiumFieldInventory.js
+++ b/lib/ConsortiumFieldInventory/ConsortiumFieldInventory.js
@@ -119,6 +119,7 @@ ConsortiumFieldInventory.propTypes = {
   filterLocations: PropTypes.func,
   holdingName: PropTypes.string.isRequired,
   isNonInteractive: PropTypes.bool,
+  isLoading: PropTypes.bool,
   labelless: PropTypes.bool,
   locationName: PropTypes.string.isRequired,
   locations: PropTypes.arrayOf(PropTypes.shape({

--- a/lib/FieldHolding/FieldHolding.js
+++ b/lib/FieldHolding/FieldHolding.js
@@ -35,12 +35,13 @@ export const FieldHolding = ({
   name,
   onChange,
   isDisabled = false,
+  isLoading = false,
   isNonInteractive = false,
   required = false,
   tenantId,
 }) => {
   const {
-    isLoading,
+    isLoading: isHoldingsLoading,
     holdings,
   } = useInstanceHoldings(instanceId, { tenantId });
 
@@ -120,7 +121,7 @@ export const FieldHolding = ({
 
   const isLookupTriggerVisible = !(isDisabled || isNonInteractive);
 
-  if (isLoading) return <Loading />;
+  if (isLoading || isHoldingsLoading) return <Loading />;
 
   return (
     selectedLocation
@@ -172,6 +173,7 @@ FieldHolding.propTypes = {
   filterLocations: PropTypes.func,
   instanceId: PropTypes.string.isRequired,
   isDisabled: PropTypes.bool,
+  isLoading: PropTypes.bool,
   isNonInteractive: PropTypes.bool,
   labelId: PropTypes.string,
   locationFieldName: PropTypes.string.isRequired,

--- a/lib/FieldHolding/FieldHolding.js
+++ b/lib/FieldHolding/FieldHolding.js
@@ -65,7 +65,7 @@ export const FieldHolding = ({
 
       setSelectedLocation(location);
     }
-  }, []);
+  }, [initialHoldingId, locationFieldName, locationsMap, values]);
 
   useEffect(() => {
     const isInitialAffiliation = tenantId === initialTenantId;

--- a/lib/FieldInventory/FieldInventory.js
+++ b/lib/FieldInventory/FieldInventory.js
@@ -9,6 +9,7 @@ export const FieldInventory = ({
   filterHoldings,
   filterLocations,
   instanceId,
+  isLoading = false,
   isNonInteractive,
   locations,
   locationIds,
@@ -35,6 +36,7 @@ export const FieldInventory = ({
         locationLabelId={locationLabelId}
         name={holdingName}
         isDisabled={disabled}
+        isLoading={isLoading}
         isNonInteractive={isNonInteractive}
         onChange={onChange}
         required={required}
@@ -77,6 +79,7 @@ FieldInventory.propTypes = {
 
   filterHoldings: PropTypes.func,
   filterLocations: PropTypes.func,
+  isLoading: PropTypes.bool,
   isNonInteractive: PropTypes.bool,
   onChange: PropTypes.func.isRequired,
   required: PropTypes.bool,


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
[UISACQCOMP-215](https://folio-org.atlassian.net/browse/UISACQCOMP-215) - `isLoading` prop for holdings when fetching affiliation related locations to display loading indicator
## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

<!-- OPTIONAL
#### TODOS and Open Questions
 [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
