### PR TITLE
UISACQCOMP-219 Create common utilities for managing response errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * ECS - Display all consortium tenants in the affiliation selection of the location lookup. Refs UISACQCOMP-202.
 * ECS - Add `isLoading` prop for `ConsortiumFieldInventory` component. Refs UISACQCOMP-215.
 * Add "Amount must be a positive number" validation for "Set exchange rate" field. Refs UISACQCOMP-218.
+* Create common utilities for managing response errors. Refs UISACQCOMP-219.
 
 ## [5.1.2](https://github.com/folio-org/stripes-acq-components/tree/v5.1.2) (2024-09-13)
 [Full Changelog](https://github.com/folio-org/stripes-acq-components/compare/v5.1.1...v5.1.2)

--- a/lib/utils/errorHandling/ResponseErrorContainer.js
+++ b/lib/utils/errorHandling/ResponseErrorContainer.js
@@ -1,3 +1,5 @@
+import { ERROR_CODE_GENERIC } from '../../constants';
+
 /**
  * @class ResponseErrorContainer
  * @description A container class for handling individual errors from a response.
@@ -13,7 +15,7 @@ export class ResponseErrorContainer {
   }
 
   get code() {
-    return this.error.code;
+    return this.error.code || ERROR_CODE_GENERIC;
   }
 
   get type() {

--- a/lib/utils/errorHandling/ResponseErrorContainer.js
+++ b/lib/utils/errorHandling/ResponseErrorContainer.js
@@ -1,0 +1,43 @@
+/**
+ * @class ResponseErrorContainer
+ * @description A container class for handling individual errors from a response.
+ * @param {Object} error - The error object containing details such as message, code, type, and parameters.
+ */
+export class ResponseErrorContainer {
+  constructor(error = {}) {
+    this.error = error;
+  }
+
+  get message() {
+    return this.error.message;
+  }
+
+  get code() {
+    return this.error.code;
+  }
+
+  get type() {
+    return this.error.type;
+  }
+
+  get parameters() {
+    return this.error.parameters;
+  }
+
+  /**
+   * @description Convert the error parameters into a Map.
+   * @returns {Map<string, Object>} A Map where the keys are parameter keys and the values are the parameter objects.
+   */
+  getParameters() {
+    return new Map(this.error.parameters?.map((parameter) => [parameter.key, parameter]));
+  }
+
+  /**
+   * @description Get a specific parameter value by its key.
+   * @param {string} key - The key of the parameter to retrieve.
+   * @returns {any} The value of the specified parameter, or undefined if not found.
+   */
+  getParameter(key) {
+    return this.getParameters().get(key)?.value;
+  }
+}

--- a/lib/utils/errorHandling/ResponseErrorContainer.test.js
+++ b/lib/utils/errorHandling/ResponseErrorContainer.test.js
@@ -1,0 +1,63 @@
+import { ResponseErrorContainer } from './ResponseErrorContainer';
+
+describe('ResponseErrorContainer', () => {
+  it('should return message, code, and type from error', () => {
+    const errorData = {
+      message: 'Test error message',
+      code: 'testCode',
+      type: 'testType',
+    };
+    const errorContainer = new ResponseErrorContainer(errorData);
+
+    expect(errorContainer.message).toBe('Test error message');
+    expect(errorContainer.code).toBe('testCode');
+    expect(errorContainer.type).toBe('testType');
+  });
+
+  it('should return undefined if no message, code, or type is provided', () => {
+    const errorContainer = new ResponseErrorContainer();
+
+    expect(errorContainer.message).toBeUndefined();
+    expect(errorContainer.code).toBeUndefined();
+    expect(errorContainer.type).toBeUndefined();
+  });
+
+  it('should return parameters map if parameters are provided', () => {
+    const errorData = {
+      parameters: [
+        { key: 'param1', value: 'value1' },
+        { key: 'param2', value: 'value2' },
+      ],
+    };
+    const errorContainer = new ResponseErrorContainer(errorData);
+
+    const parametersMap = errorContainer.getParameters();
+
+    expect(parametersMap.size).toBe(2);
+    expect(parametersMap.get('param1').value).toBe('value1');
+    expect(parametersMap.get('param2').value).toBe('value2');
+  });
+
+  it('should return an empty map if no parameters are provided', () => {
+    const errorContainer = new ResponseErrorContainer();
+
+    const parametersMap = errorContainer.getParameters();
+
+    expect(parametersMap.size).toBe(0);
+  });
+
+  it('should return parameter value for a given key', () => {
+    const errorData = {
+      parameters: [{ key: 'param1', value: 'value1' }],
+    };
+    const errorContainer = new ResponseErrorContainer(errorData);
+
+    expect(errorContainer.getParameter('param1')).toBe('value1');
+  });
+
+  it('should return undefined if parameter key is not found', () => {
+    const errorContainer = new ResponseErrorContainer();
+
+    expect(errorContainer.getParameter('nonexistentKey')).toBeUndefined();
+  });
+});

--- a/lib/utils/errorHandling/ResponseErrorContainer.test.js
+++ b/lib/utils/errorHandling/ResponseErrorContainer.test.js
@@ -1,3 +1,6 @@
+/* Developed collaboratively using AI (GitHub Copilot) */
+
+import { ERROR_CODE_GENERIC } from '../../constants';
 import { ResponseErrorContainer } from './ResponseErrorContainer';
 
 describe('ResponseErrorContainer', () => {
@@ -14,11 +17,11 @@ describe('ResponseErrorContainer', () => {
     expect(errorContainer.type).toBe('testType');
   });
 
-  it('should return undefined if no message, code, or type is provided', () => {
+  it('should return undefined if no message or type is provided, and the generic code', () => {
     const errorContainer = new ResponseErrorContainer();
 
     expect(errorContainer.message).toBeUndefined();
-    expect(errorContainer.code).toBeUndefined();
+    expect(errorContainer.code).toBe(ERROR_CODE_GENERIC);
     expect(errorContainer.type).toBeUndefined();
   });
 

--- a/lib/utils/errorHandling/ResponseErrorsContainer.js
+++ b/lib/utils/errorHandling/ResponseErrorsContainer.js
@@ -1,0 +1,149 @@
+import { ERROR_CODE_GENERIC } from '../../constants';
+import { ResponseErrorContainer } from './ResponseErrorContainer';
+
+const ERROR_MESSAGE_GENERIC = 'An unknown error occurred';
+
+/**
+ * @class
+ * @description Container for response errors
+ * @param {Object} responseBody - Response body
+ * @param {Response} response - Response
+ */
+export class ResponseErrorsContainer {
+  /* private */ constructor(responseBody, response) {
+    this.originalResponseBody = responseBody;
+    this.originalResponse = response;
+
+    // Initialize the map of errors
+    this.errorsMap = new Map(
+      responseBody.errors?.reduce((acc, error) => {
+        const errorContainer = this.getStructuredError(error);
+
+        acc.push([errorContainer.code || ERROR_CODE_GENERIC, errorContainer]);
+
+        return acc;
+      }, []),
+    );
+
+    this.totalRecords = responseBody.total_records;
+  }
+
+  /**
+   * @static
+   * @description Create a new instance of ResponseErrorsContainer.
+   * @param {Response} response - The Response object from which to create the error handler.
+   * @returns {Promise<{handler: ResponseErrorsContainer}>} A promise that resolves to an object containing the error handler.
+   */
+  static async create(response) {
+    try {
+      const responseBody = await response.clone().json();
+
+      return {
+        handler: (
+          responseBody?.errors
+            ? new ResponseErrorsContainer(responseBody, response)
+            : new ResponseErrorsContainer({ errors: [responseBody], total_records: 1 }, response)
+        ),
+      };
+    } catch (error) {
+      return {
+        handler: new ResponseErrorsContainer({ errors: [error], total_records: 1 }, response),
+      };
+    }
+  }
+
+  /**
+   * @description Handle the errors using a given strategy.
+   * @param {Object} strategy - The error handling strategy to be applied.
+   */
+  handle(strategy) {
+    return strategy.handle(this);
+  }
+
+  get status() {
+    return this.originalResponse?.status;
+  }
+
+  /**
+   * @description Get an array of error messages.
+   * @returns {Array<string | undefined>} An array of error messages.
+   */
+  get errorMessages() {
+    return this.errors.map((error) => error.message);
+  }
+
+  /**
+   * @description Get an array of error codes.
+   * @returns {Array<string | undefined>} An array of error codes.
+   */
+  get errorCodes() {
+    return this.errors.map((error) => error.code);
+  }
+
+  /**
+   * @description Get all errors as an array.
+   * @returns {Array<ResponseErrorContainer>} An array of error containers.
+   */
+  get errors() {
+    return Array.from(this.errorsMap.values());
+  }
+
+  /**
+   * @description Get all errors as a map.
+   * @returns {Map<string, ResponseErrorContainer>} A map of errors with error codes as keys.
+   */
+  getErrors() {
+    return this.errorsMap;
+  }
+
+  /**
+   * @description Get a specific error by its code or the first error if no code is provided.
+   * @param {string} [code] - The error code to search for.
+   * @returns {ResponseErrorContainer} The corresponding error container or a generic error if not found.
+   */
+  getError(code) {
+    return (code ? this.errorsMap.get(code) : this.errors[0]) || new ResponseErrorContainer();
+  }
+
+  /**
+   * @private
+   * @description Normalize an unknown error into a structured ResponseErrorContainer.
+   * @param {unknown} error - The unstructured error object.
+   * @returns {ResponseErrorContainer} A structured error container.
+   */
+  getStructuredError(error) {
+    let normalizedError;
+
+    if (typeof error === 'string') {
+      try {
+        const parsed = JSON.parse(error);
+
+        normalizedError = {
+          message: parsed.message || error,
+          code: parsed.code || ERROR_CODE_GENERIC,
+          ...parsed,
+        };
+      } catch {
+        normalizedError = {
+          message: error,
+          code: ERROR_CODE_GENERIC,
+        };
+      }
+    } else {
+      let message;
+
+      try {
+        message = error?.message || error?.error || JSON.stringify(error);
+      } catch {
+        message = ERROR_MESSAGE_GENERIC;
+      }
+      normalizedError = {
+        code: error?.code || ERROR_CODE_GENERIC,
+        message,
+        ...error,
+      };
+    }
+
+    return new ResponseErrorContainer(normalizedError);
+  }
+}

--- a/lib/utils/errorHandling/ResponseErrorsContainer.test.js
+++ b/lib/utils/errorHandling/ResponseErrorsContainer.test.js
@@ -1,0 +1,54 @@
+import { ERROR_CODE_GENERIC } from '../../constants';
+import { ResponseErrorsContainer } from './ResponseErrorsContainer';
+import { ResponseErrorContainer } from './ResponseErrorContainer';
+
+describe('ResponseErrorsContainer', () => {
+  let mockResponse; let
+    mockResponseBody;
+
+  beforeEach(() => {
+    mockResponseBody = {
+      errors: [{ code: '404', message: 'Not found' }],
+      total_records: 1,
+    };
+    mockResponse = {
+      clone: jest.fn().mockReturnThis(),
+      json: jest.fn().mockResolvedValue(mockResponseBody),
+      status: 404,
+    };
+  });
+
+  it('should create a new ResponseErrorsContainer instance from a response', async () => {
+    const { handler } = await ResponseErrorsContainer.create(mockResponse);
+
+    expect(handler).toBeInstanceOf(ResponseErrorsContainer);
+    expect(handler.status).toBe(404); // Check for status
+    expect(handler.errorMessages).toEqual(['Not found']);
+  });
+
+  it('should return a specific error by code', async () => {
+    const { handler } = await ResponseErrorsContainer.create(mockResponse);
+    const error = handler.getError('404');
+
+    expect(error).toBeInstanceOf(ResponseErrorContainer);
+    expect(error.message).toBe('Not found');
+    expect(error.code).toBe('404');
+  });
+
+  it('should handle unknown errors', async () => {
+    const mockUnknownError = { errors: ['Unknown error'] };
+
+    mockResponse.json.mockResolvedValueOnce(mockUnknownError);
+
+    const { handler } = await ResponseErrorsContainer.create(mockResponse);
+
+    expect(handler.errorMessages).toEqual(['Unknown error']);
+  });
+
+  it('should return generic error when no error code is found', async () => {
+    const { handler } = await ResponseErrorsContainer.create(mockResponse);
+    const error = handler.getError('500');
+
+    expect(error.code).toBe(ERROR_CODE_GENERIC);
+  });
+});

--- a/lib/utils/errorHandling/ResponseErrorsContainer.test.js
+++ b/lib/utils/errorHandling/ResponseErrorsContainer.test.js
@@ -1,8 +1,8 @@
 /* Developed collaboratively using AI (GitHub Copilot) */
 
 import { ERROR_CODE_GENERIC } from '../../constants';
-import { ResponseErrorsContainer } from './ResponseErrorsContainer';
 import { ResponseErrorContainer } from './ResponseErrorContainer';
+import { ResponseErrorsContainer } from './ResponseErrorsContainer';
 
 describe('ResponseErrorsContainer', () => {
   let mockResponse; let mockResponseBody; let

--- a/lib/utils/errorHandling/ResponseErrorsContainer.test.js
+++ b/lib/utils/errorHandling/ResponseErrorsContainer.test.js
@@ -1,53 +1,146 @@
+/* Developed collaboratively using AI (GitHub Copilot) */
+
 import { ERROR_CODE_GENERIC } from '../../constants';
 import { ResponseErrorsContainer } from './ResponseErrorsContainer';
 import { ResponseErrorContainer } from './ResponseErrorContainer';
 
 describe('ResponseErrorsContainer', () => {
-  let mockResponse; let
-    mockResponseBody;
+  let mockResponse; let mockResponseBody; let
+    errorStrategy;
 
   beforeEach(() => {
     mockResponseBody = {
-      errors: [{ code: '404', message: 'Not found' }],
-      total_records: 1,
+      errors: [
+        { code: 'foo', message: 'Something went wrong' },
+        { code: 'bar', message: 'Internal server error' },
+      ],
+      total_records: 2,
     };
+
     mockResponse = {
       clone: jest.fn().mockReturnThis(),
       json: jest.fn().mockResolvedValue(mockResponseBody),
-      status: 404,
+      status: 500,
+    };
+
+    errorStrategy = {
+      handle: jest.fn(),
     };
   });
 
-  it('should create a new ResponseErrorsContainer instance from a response', async () => {
+  it('should create an instance with response body and status', async () => {
     const { handler } = await ResponseErrorsContainer.create(mockResponse);
 
     expect(handler).toBeInstanceOf(ResponseErrorsContainer);
-    expect(handler.status).toBe(404); // Check for status
-    expect(handler.errorMessages).toEqual(['Not found']);
+    expect(handler.status).toBe(500); // Check HTTP status
+    expect(handler.totalRecords).toBe(2); // Check total records
   });
 
-  it('should return a specific error by code', async () => {
+  it('should create a handler when response contains a single error object', async () => {
+    const singleErrorBody = { code: 'baz', message: 'Bad Request' };
+
+    mockResponse.json.mockResolvedValueOnce(singleErrorBody);
+
     const { handler } = await ResponseErrorsContainer.create(mockResponse);
-    const error = handler.getError('404');
+
+    expect(handler).toBeInstanceOf(ResponseErrorsContainer);
+    expect(handler.errorMessages).toEqual(['Bad Request']);
+  });
+
+  it('should return error messages as an array', async () => {
+    const { handler } = await ResponseErrorsContainer.create(mockResponse);
+
+    expect(handler.errorMessages).toEqual(['Something went wrong', 'Internal server error']);
+  });
+
+  it('should return error codes as an array', async () => {
+    const { handler } = await ResponseErrorsContainer.create(mockResponse);
+
+    expect(handler.errorCodes).toEqual(['foo', 'bar']);
+  });
+
+  it('should return all errors as an array of ResponseErrorContainer instances', async () => {
+    const { handler } = await ResponseErrorsContainer.create(mockResponse);
+    const errors = handler.errors;
+
+    expect(errors).toHaveLength(2);
+    expect(errors[0]).toBeInstanceOf(ResponseErrorContainer);
+    expect(errors[1].code).toBe('bar');
+  });
+
+  it('should return all errors as a map', async () => {
+    const { handler } = await ResponseErrorsContainer.create(mockResponse);
+    const errorsMap = handler.getErrors();
+
+    expect(errorsMap.size).toBe(2); // Check size of map
+    expect(errorsMap.get('foo').message).toBe('Something went wrong'); // Check first error
+  });
+
+  it('should get a specific error by code', async () => {
+    const { handler } = await ResponseErrorsContainer.create(mockResponse);
+    const error = handler.getError('foo');
 
     expect(error).toBeInstanceOf(ResponseErrorContainer);
-    expect(error.message).toBe('Not found');
-    expect(error.code).toBe('404');
+    expect(error.code).toBe('foo');
+    expect(error.message).toBe('Something went wrong');
   });
 
-  it('should handle unknown errors', async () => {
-    const mockUnknownError = { errors: ['Unknown error'] };
-
-    mockResponse.json.mockResolvedValueOnce(mockUnknownError);
-
+  it('should return the first error when no code is provided', async () => {
     const { handler } = await ResponseErrorsContainer.create(mockResponse);
+    const error = handler.getError();
 
-    expect(handler.errorMessages).toEqual(['Unknown error']);
+    expect(error.code).toBe('foo');
   });
 
-  it('should return generic error when no error code is found', async () => {
+  it('should return a generic error when the requested code is not found', async () => {
     const { handler } = await ResponseErrorsContainer.create(mockResponse);
-    const error = handler.getError('500');
+    const error = handler.getError('999'); // Code that does not exist
+
+    expect(error.code).toBe(ERROR_CODE_GENERIC); // Fallback to generic error
+  });
+
+  it('should normalize string error to structured error container', () => {
+    const stringError = 'This is an error';
+    const handler = new ResponseErrorsContainer({ errors: [stringError], total_records: 1 }, mockResponse);
+
+    const error = handler.getError();
+
+    expect(error.message).toBe(stringError);
+    expect(error.code).toBe(ERROR_CODE_GENERIC);
+  });
+
+  it('should normalize invalid JSON error string to generic error', () => {
+    const invalidJsonError = '{"invalidJson": true';
+    const handler = new ResponseErrorsContainer({ errors: [invalidJsonError], total_records: 1 }, mockResponse);
+
+    const error = handler.getError();
+
+    expect(error.message).toBe(invalidJsonError); // Should return the original string
+    expect(error.code).toBe(ERROR_CODE_GENERIC);
+  });
+
+  it('should handle unknown objects without message by converting them to a string', () => {
+    const unknownError = { invalid: 'no message' };
+    const handler = new ResponseErrorsContainer({ errors: [unknownError], total_records: 1 }, mockResponse);
+
+    const error = handler.getError();
+
+    expect(error.message).toBe(JSON.stringify(unknownError)); // Should stringify the object
+    expect(error.code).toBe(ERROR_CODE_GENERIC);
+  });
+
+  it('should handle response errors using a provided strategy', async () => {
+    const { handler } = await ResponseErrorsContainer.create(mockResponse);
+
+    handler.handle(errorStrategy);
+    expect(errorStrategy.handle).toHaveBeenCalledWith(handler); // Ensure strategy is invoked with the handler
+  });
+
+  it('should handle empty error body by returning generic error', async () => {
+    mockResponse.json.mockResolvedValueOnce({}); // Empty body
+    const { handler } = await ResponseErrorsContainer.create(mockResponse);
+
+    const error = handler.getError();
 
     expect(error.code).toBe(ERROR_CODE_GENERIC);
   });

--- a/lib/utils/errorHandling/index.js
+++ b/lib/utils/errorHandling/index.js
@@ -1,0 +1,1 @@
+export { ResponseErrorsContainer } from './ResponseErrorsContainer';

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -4,6 +4,7 @@ export * from './calculateFundAmount';
 export * from './consortia';
 export * from './createClearFilterHandler';
 export * from './downloadBase64';
+export * from './errorHandling';
 export * from './EventEmitter';
 export * from './fetchAllRecords';
 export * from './fetchExportDataByIds';


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://folio-org.atlassian.net/browse/UISACQCOMP-219

- The ResponseErrorsContainer utility is designed to handle and manage errors that arise from HTTP responses in a structured way.
- It standardizes errors into a manageable format, regardless of whether the error comes in a specific format or is generic/unknown.
- It allows easy retrieval of error messages, codes, and handling via various strategies to streamline error processing.
- The utility simplifies working with multiple errors by storing them in a structured format, such as a `Map`.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
1. The class encapsulates the original HTTP response and parses the response body, particularly focusing on extracting errors.
2. It provides both static and instance methods to:
   - Parse errors, normalize them, and store them in a map for quick access.
   - Offer error retrieval by code or default to the first error if no specific code is provided.
   - Enable integration with external strategies for customized error handling.
3. It supports asynchronous creation of error containers, making it adaptable to promise-based response handling.
4. The utility normalizes different types of errors (e.g., strings, JSON objects) into a consistent structure using the `ResponseErrorContainer` class for downstream usage.
<!-- OPTIONAL
#### TODOS and Open Questions
 [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
