### PR TITLE
UISACQCOMP-222 Use `actionDate` value for version history card title instead of `eventDate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Add "Amount must be a positive number" validation for "Set exchange rate" field. Refs UISACQCOMP-218.
 * Create common utilities for managing response errors. Refs UISACQCOMP-219.
 * ECS - expand `ConsortiumFieldInventory` component with `additionalAffiliationIds` prop to display affiliation name for User without affiliation in specific tenant. Refs UISACQCOMP-220.
+* Use `actionDate` value for version history card title instead of `eventDate`. Refs UISACQCOMP-222.
 
 ## [5.1.2](https://github.com/folio-org/stripes-acq-components/tree/v5.1.2) (2024-09-13)
 [Full Changelog](https://github.com/folio-org/stripes-acq-components/compare/v5.1.1...v5.1.2)

--- a/lib/VersionHistory/VersionHistoryPane/VersionHistoryPane.js
+++ b/lib/VersionHistory/VersionHistoryPane/VersionHistoryPane.js
@@ -54,7 +54,7 @@ const VersionHistoryPane = ({
   const versionCards = useMemo(() => (
     versionsToDisplay.map(({
       id: versionId,
-      eventDate,
+      actionDate,
       userId,
     }, i) => {
       const user = usersMap[userId];
@@ -83,7 +83,7 @@ const VersionHistoryPane = ({
           isCurrent={versionId === currentVersion}
           isLatest={i === 0}
           onSelect={onSelectVersion}
-          title={<FolioFormattedTime dateString={eventDate} />}
+          title={<FolioFormattedTime dateString={actionDate} />}
           source={source}
           changedFields={changedFields}
         />


### PR DESCRIPTION
## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://folio-org.atlassian.net/browse/UISACQCOMP-222

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
