### PR TITLE
UISACQCOMP-230 Move reusable version history components to the ACQ lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## (6.1.0 IN PROGRESS)
 
 * Add more reusable hooks and utilities. Refs UISACQCOMP-228.
+* Move reusable version history components to the ACQ lib. Refs UISACQCOMP-230.
 
 ## (6.0.1 IN PROGRESS)
 

--- a/lib/VersionHistory/components/VersionCheckbox/VersionCheckbox.js
+++ b/lib/VersionHistory/components/VersionCheckbox/VersionCheckbox.js
@@ -1,0 +1,40 @@
+import PropTypes from 'prop-types';
+import { useContext, useMemo } from 'react';
+
+import { Checkbox } from '@folio/stripes/components';
+
+import { VersionViewContext } from '../../VersionViewContext';
+
+export const VersionCheckbox = ({
+  checked,
+  label,
+  name,
+  ...props
+}) => {
+  const versionContext = useContext(VersionViewContext);
+  const isUpdated = useMemo(() => (
+    versionContext?.paths?.includes(name)
+  ), [name, versionContext?.paths]);
+
+  const checkboxLabel = isUpdated ? <mark>{label}</mark> : label;
+
+  return (
+    <Checkbox
+      checked={Boolean(checked)}
+      disabled
+      label={checkboxLabel}
+      vertical
+      {...props}
+    />
+  );
+};
+
+VersionCheckbox.defaultProps = {
+  checked: false,
+};
+
+VersionCheckbox.propTypes = {
+  checked: PropTypes.bool,
+  label: PropTypes.node.isRequired,
+  name: PropTypes.string.isRequired,
+};

--- a/lib/VersionHistory/components/VersionCheckbox/VersionCheckbox.test.js
+++ b/lib/VersionHistory/components/VersionCheckbox/VersionCheckbox.test.js
@@ -26,8 +26,6 @@ describe('VersionCheckbox', () => {
   it('renders with marked label when name is in context paths', () => {
     renderVersionCheckbox({}, { paths: ['testName'] });
 
-    screen.debug();
-
     expect(screen.getByText('Test Label').closest('mark')).toBeInTheDocument();
   });
 

--- a/lib/VersionHistory/components/VersionCheckbox/VersionCheckbox.test.js
+++ b/lib/VersionHistory/components/VersionCheckbox/VersionCheckbox.test.js
@@ -1,0 +1,39 @@
+import {
+  render,
+  screen,
+} from '@testing-library/react';
+
+import { VersionViewContext } from '../../VersionViewContext';
+import { VersionCheckbox } from './VersionCheckbox';
+
+const defaultProps = {
+  label: 'Test Label',
+  name: 'testName',
+};
+
+const renderVersionCheckbox = (props = {}, contextValue = {}) => {
+  return render(
+    <VersionViewContext.Provider value={contextValue}>
+      <VersionCheckbox
+        {...defaultProps}
+        {...props}
+      />
+    </VersionViewContext.Provider>,
+  );
+};
+
+describe('VersionCheckbox', () => {
+  it('renders with marked label when name is in context paths', () => {
+    renderVersionCheckbox({}, { paths: ['testName'] });
+
+    screen.debug();
+
+    expect(screen.getByText('Test Label').closest('mark')).toBeInTheDocument();
+  });
+
+  it('renders with normal label when name is not in context paths', () => {
+    renderVersionCheckbox({}, { paths: ['otherName'] });
+
+    expect(screen.getByText('Test Label').closest('mark')).not.toBeInTheDocument();
+  });
+});

--- a/lib/VersionHistory/components/VersionCheckbox/index.js
+++ b/lib/VersionHistory/components/VersionCheckbox/index.js
@@ -1,0 +1,1 @@
+export { VersionCheckbox } from './VersionCheckbox';

--- a/lib/VersionHistory/components/VersionKeyValue/VersionKeyValue.js
+++ b/lib/VersionHistory/components/VersionKeyValue/VersionKeyValue.js
@@ -1,0 +1,49 @@
+import PropTypes from 'prop-types';
+import {
+  useContext,
+  useMemo,
+} from 'react';
+
+import {
+  KeyValue,
+  NoValue,
+} from '@folio/stripes/components';
+
+import { VersionViewContext } from '../../VersionViewContext';
+
+export const VersionKeyValue = ({
+  children,
+  label,
+  multiple,
+  name,
+  value,
+}) => {
+  const versionContext = useContext(VersionViewContext);
+  const isUpdated = useMemo(() => (
+    multiple
+      ? versionContext?.paths?.find((field) => new RegExp(`^${name}\\[\\d\\]$`).test(field))
+      : versionContext?.paths?.includes(name)
+  ), [multiple, name, versionContext?.paths]);
+
+  const content = (children || value) || <NoValue />;
+  const displayValue = isUpdated ? <mark>{content}</mark> : content;
+
+  return (
+    <KeyValue
+      label={label}
+      value={displayValue}
+    />
+  );
+};
+
+VersionKeyValue.defaultProps = {
+  multiple: false,
+};
+
+VersionKeyValue.propTypes = {
+  children: PropTypes.node,
+  label: PropTypes.node.isRequired,
+  multiple: PropTypes.bool,
+  name: PropTypes.string.isRequired,
+  value: PropTypes.node,
+};

--- a/lib/VersionHistory/components/VersionKeyValue/VersionKeyValue.test.js
+++ b/lib/VersionHistory/components/VersionKeyValue/VersionKeyValue.test.js
@@ -1,0 +1,64 @@
+import {
+  render,
+  screen,
+} from '@testing-library/react';
+
+import { VersionViewContext } from '../../VersionViewContext';
+import { VersionKeyValue } from './VersionKeyValue';
+
+const defaultProps = {
+  label: 'Test Label',
+  value: 'Test Value',
+  name: 'testName',
+};
+
+const renderComponent = (props = {}, contextValue = {}) => {
+  return render(
+    <VersionViewContext.Provider value={contextValue}>
+      <VersionKeyValue
+        {...defaultProps}
+        {...props}
+      />
+    </VersionViewContext.Provider>,
+  );
+};
+
+describe('VersionKeyValue', () => {
+  it('should render label and value', () => {
+    renderComponent();
+
+    expect(screen.getByText('Test Label')).toBeInTheDocument();
+    expect(screen.getByText('Test Value')).toBeInTheDocument();
+  });
+
+  it('should render NoValue when value is not provided', () => {
+    renderComponent({ value: undefined });
+
+    expect(screen.getByText('Test Label')).toBeInTheDocument();
+    expect(screen.getByText('stripes-components.noValue.noValueSet')).toBeInTheDocument();
+  });
+
+  it('should highlight updated value', () => {
+    renderComponent({ name: 'testName' }, { paths: ['testName'] });
+
+    expect(screen.getByText('Test Value').closest('mark')).toBeInTheDocument();
+  });
+
+  it('should not highlight non-updated value', () => {
+    renderComponent({}, { paths: ['anotherName'] });
+
+    expect(screen.getByText('Test Value').closest('mark')).not.toBeInTheDocument();
+  });
+
+  it('should highlight updated value for multiple fields', () => {
+    renderComponent({ multiple: true }, { paths: ['testName[0]'] });
+
+    expect(screen.getByText('Test Value').closest('mark')).toBeInTheDocument();
+  });
+
+  it('should not highlight non-updated value for multiple fields', () => {
+    renderComponent({ multiple: true }, { paths: ['anotherName[0]'] });
+
+    expect(screen.getByText('Test Value').closest('mark')).not.toBeInTheDocument();
+  });
+});

--- a/lib/VersionHistory/components/VersionKeyValue/index.js
+++ b/lib/VersionHistory/components/VersionKeyValue/index.js
@@ -1,0 +1,1 @@
+export { VersionKeyValue } from './VersionKeyValue';

--- a/lib/VersionHistory/components/VersionView/VersionView.js
+++ b/lib/VersionHistory/components/VersionView/VersionView.js
@@ -1,0 +1,76 @@
+import PropTypes from 'prop-types';
+import {
+  memo,
+  useMemo,
+} from 'react';
+import { FormattedMessage } from 'react-intl';
+
+import {
+  Layout,
+  LoadingPane,
+  Pane,
+  PaneMenu,
+} from '@folio/stripes/components';
+
+import { TagsBadge } from '../../../Tags';
+import { VersionHistoryButton } from '../../VersionHistoryButton';
+
+const VersionView = ({
+  children,
+  id,
+  isLoading,
+  onClose,
+  tags,
+  versionId,
+  ...props
+}) => {
+  const isVersionExist = Boolean(versionId && !isLoading);
+
+  const lastMenu = useMemo(() => (
+    <PaneMenu>
+      {tags && (
+        <TagsBadge
+          disabled
+          tagsQuantity={tags.length}
+        />
+      )}
+      <VersionHistoryButton disabled />
+    </PaneMenu>
+  ), [tags]);
+
+  if (isLoading) return <LoadingPane />;
+
+  return (
+    <Pane
+      id={`${id}-version-view`}
+      defaultWidth="fill"
+      onClose={onClose}
+      lastMenu={lastMenu}
+      {...props}
+    >
+      {
+        isVersionExist
+          ? children
+          : (
+            <Layout
+              element="span"
+              className="flex centerContent"
+            >
+              <FormattedMessage id="stripes-acq-components.versionHistory.noVersion" />
+            </Layout>
+          )
+      }
+    </Pane>
+  );
+};
+
+VersionView.propTypes = {
+  children: PropTypes.node.isRequired,
+  id: PropTypes.string.isRequired,
+  isLoading: PropTypes.bool,
+  onClose: PropTypes.func,
+  tags: PropTypes.arrayOf(PropTypes.object),
+  versionId: PropTypes.string,
+};
+
+export default memo(VersionView);

--- a/lib/VersionHistory/components/VersionView/VersionView.test.js
+++ b/lib/VersionHistory/components/VersionView/VersionView.test.js
@@ -1,0 +1,52 @@
+import {
+  render,
+  screen,
+} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import VersionView from './VersionView';
+
+const defaultProps = {
+  children: <div>Version Content</div>,
+  id: 'test-id',
+  isLoading: false,
+  onClose: jest.fn(),
+  tags: [{ id: 'tag1' }, { id: 'tag2' }],
+  versionId: 'version1',
+  dismissible: true,
+};
+
+const renderComponent = (props = {}) => render(
+  <VersionView
+    {...defaultProps}
+    {...props}
+  />,
+);
+
+describe('VersionView', () => {
+  it('should render loading pane when isLoading is true', () => {
+    renderComponent({ isLoading: true });
+
+    expect(screen.queryByText('Version Content')).not.toBeInTheDocument();
+  });
+
+  it('should render children when version exists and is not loading', () => {
+    renderComponent();
+
+    expect(screen.getByText('Version Content')).toBeInTheDocument();
+  });
+
+  it('should render no version message when version does not exist', () => {
+    renderComponent({ versionId: null });
+
+    expect(screen.getByText('stripes-acq-components.versionHistory.noVersion')).toBeInTheDocument();
+  });
+
+  it('should call onClose when Pane onClose is triggered', async () => {
+    renderComponent();
+
+    await userEvent.click(screen.getByRole('button', { name: 'stripes-components.closeItem' }));
+
+    expect(defaultProps.onClose).toHaveBeenCalled();
+  });
+});

--- a/lib/VersionHistory/components/VersionView/index.js
+++ b/lib/VersionHistory/components/VersionView/index.js
@@ -1,0 +1,1 @@
+export { default as VersionView } from './VersionView';

--- a/lib/VersionHistory/components/index.js
+++ b/lib/VersionHistory/components/index.js
@@ -1,0 +1,3 @@
+export { VersionCheckbox } from './VersionCheckbox';
+export { VersionKeyValue } from './VersionKeyValue';
+export { VersionView } from './VersionView';

--- a/lib/VersionHistory/index.js
+++ b/lib/VersionHistory/index.js
@@ -1,3 +1,4 @@
+export * from './components';
 export { getFieldLabels } from './getFieldLabels';
 export { getHighlightedFields } from './getHighlightedFields';
 export * from './hooks';

--- a/lib/constants/api.js
+++ b/lib/constants/api.js
@@ -1,6 +1,7 @@
 export const ACQUISITION_METHODS_API = 'orders/acquisition-methods';
 export const ACQUISITIONS_UNITS_API = 'acquisitions-units/units';
 export const ACQUISITIONS_UNIT_MEMBERSHIPS_API = 'acquisitions-units/memberships';
+export const AUDIT_ACQ_EVENTS_API = 'audit-data/acquisition';
 export const BATCH_GROUPS_API = 'batch-groups';
 export const BUDGETS_API = 'finance/budgets';
 export const CAMPUSES_API = 'location-units/campuses';

--- a/lib/hooks/useLineHoldings/useLineHoldings.js
+++ b/lib/hooks/useLineHoldings/useLineHoldings.js
@@ -11,9 +11,9 @@ export const useLineHoldings = (holdingIds) => {
 
   const query = useQuery(
     [namespace, holdingIds],
-    () => {
+    ({ signal }) => {
       return batchRequest(
-        ({ params: searchParams }) => ky.get(HOLDINGS_API, { searchParams }).json(),
+        ({ params: searchParams }) => ky.get(HOLDINGS_API, { searchParams, signal }).json(),
         holdingIds,
       );
     },

--- a/lib/hooks/useOrganization/useOrganization.js
+++ b/lib/hooks/useOrganization/useOrganization.js
@@ -23,7 +23,7 @@ export const useOrganization = (id, options = {}) => {
     isLoading,
   } = useQuery({
     queryKey: [namespace, id, tenantId],
-    queryFn: () => ky.get(`${VENDORS_API}/${id}`).json(),
+    queryFn: ({ signal }) => ky.get(`${VENDORS_API}/${id}`, { signal }).json(),
     enabled: enabled && Boolean(id),
     ...queryOptions,
   });

--- a/lib/hooks/useOrganization/useOrganization.test.js
+++ b/lib/hooks/useOrganization/useOrganization.test.js
@@ -11,8 +11,6 @@ import { VENDORS_API } from '../../constants';
 import { useOrganization } from './useOrganization';
 
 const queryClient = new QueryClient();
-
-// eslint-disable-next-line react/prop-types
 const wrapper = ({ children }) => (
   <QueryClientProvider client={queryClient}>
     {children}
@@ -42,6 +40,6 @@ describe('useOrganization', () => {
     await waitFor(() => !result.current.isLoading);
 
     expect(result.current.organization).toEqual(organization);
-    expect(mockGet).toHaveBeenCalledWith(`${VENDORS_API}/${organization.id}`);
+    expect(mockGet).toHaveBeenCalledWith(`${VENDORS_API}/${organization.id}`, expect.any(Object));
   });
 });

--- a/lib/hooks/useUsersBatch/useUsersBatch.js
+++ b/lib/hooks/useUsersBatch/useUsersBatch.js
@@ -25,9 +25,9 @@ export const useUsersBatch = (userIds, options = {}) => {
     isLoading,
   } = useQuery(
     [namespace, userIds],
-    async () => {
+    async ({ signal }) => {
       const response = await batchRequest(
-        ({ params: searchParams }) => ky.get(USERS_API, { searchParams }).json(),
+        ({ params: searchParams }) => ky.get(USERS_API, { searchParams, signal }).json(),
         userIds,
       );
 

--- a/lib/hooks/useUsersBatch/useUsersBatch.test.js
+++ b/lib/hooks/useUsersBatch/useUsersBatch.test.js
@@ -10,8 +10,6 @@ import { USERS_API } from '../../constants';
 import { useUsersBatch } from './useUsersBatch';
 
 const queryClient = new QueryClient();
-
-// eslint-disable-next-line react/prop-types
 const wrapper = ({ children }) => (
   <QueryClientProvider client={queryClient}>
     {children}
@@ -45,6 +43,7 @@ describe('useUsersBatch', () => {
       searchParams: expect.objectContaining({
         query: userIds.map(id => `id==${id}`).join(' or '),
       }),
+      signal: expect.any(AbortSignal),
     });
   });
 });

--- a/translations/stripes-acq-components/en.json
+++ b/translations/stripes-acq-components/en.json
@@ -221,6 +221,7 @@
   "versionHistory.card.version.current": "Current version",
   "versionHistory.card.version.original": "Original version",
   "versionHistory.deletedRecord": "Record deleted",
+  "versionHistory.noVersion": "No version history to display.",
   "versionHistory.pane.header": "Version history",
   "versionHistory.pane.sub": "{count, plural, one {# version} other {# versions}}",
 


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://folio-org.atlassian.net/browse/UISACQCOMP-230

Since the feature with the display of version history extends to other applications, a single source of common components for displaying versions and highlighting changed fields is required.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
Based on the implementation of the feature in `ui-orders`, derive a set of common utilities and components.
<!-- OPTIONAL
#### TODOS and Open Questions
 [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
