### PR TITLE
UISACQCOMP-239 Claim locations from all members for locations filter when `crossTenant` equals `true`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Move reusable version history hook useVersionHistoryValueResolvers to the ACQ lib. Refs UISACQCOMP-235.
 * Move reusable claiming code from `ui-receiving` to the shared library. Refs UISACQCOMP-236.
 * Support `CLAIMS` export type in the `useIntegrationConfigs` hook. Refs UISACQCOMP-238.
+* Claim locations from all members for locations filter when `crossTenant` equals `true`. Refs UISACQCOMP-239.
 
 ## [6.0.2](https://github.com/folio-org/stripes-acq-components/tree/v6.0.2) (2024-12-04)
 [Full Changelog](https://github.com/folio-org/stripes-acq-components/compare/v6.0.1...v6.0.2)

--- a/lib/LocationFilter/LocationFilterContainer.js
+++ b/lib/LocationFilter/LocationFilterContainer.js
@@ -19,7 +19,10 @@ const LocationFilterContainer = ({
     isLoading,
   } = useLocationsQuery({
     consortium: crossTenant,
-    tenantId,
+    /*
+      Locations filter should ignore `tenantId` param when `crossTenant` equals `true` to be able to display valid references from all selected members.
+    */
+    tenantId: crossTenant ? undefined : tenantId,
   });
 
   return (


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://folio-org.atlassian.net/browse/UISACQCOMP-239

This pull request enhances the `stripes-acq-components` module by updating the location filtering functionality to support cross-tenant environments. 

**Key Changes:**

- **Cross-Tenant Location Retrieval:** When the `crossTenant` parameter is set to `true`, the location filter now retrieves locations from all tenant members, enabling more comprehensive data access across multiple tenants.

<!-- OPTIONAL
#### TODOS and Open Questions
 [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF or video is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->

https://github.com/user-attachments/assets/2be8bf1a-fb74-425c-852d-7f0658f3d81e


<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
