### PR TITLE
 UISACQCOMP-243 Add labelless prop to FieldTags component to hide label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 * Move reusable version history hook useVersionHistoryValueResolvers to the ACQ lib. Refs UISACQCOMP-235.
 * Move reusable claiming code from `ui-receiving` to the shared library. Refs UISACQCOMP-236.
 * Support `CLAIMS` export type in the `useIntegrationConfigs` hook. Refs UISACQCOMP-238.
+
+## [6.0.4](https://github.com/folio-org/stripes-acq-components/tree/v6.0.4) (2025-01-21)
+[Full Changelog](https://github.com/folio-org/stripes-acq-components/compare/v6.0.3...v6.0.4)
+
 * Exclude unsupported currencies on `getInvoiceExportData`. Refs UISACQCOMP-237.
 
 ## [6.0.3](https://github.com/folio-org/stripes-acq-components/tree/v6.0.3) (2024-12-27)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Move reusable version history hook useVersionHistoryValueResolvers to the ACQ lib. Refs UISACQCOMP-235.
 * Move reusable claiming code from `ui-receiving` to the shared library. Refs UISACQCOMP-236.
 * Support `CLAIMS` export type in the `useIntegrationConfigs` hook. Refs UISACQCOMP-238.
-* Add `labelless` prop to `FieldTags` component to hide label. Refs UISACQCOMP-243.
+* Add `labelless`, `fullWidth`, `marginBottom0` props to `FieldTags` component. Refs UISACQCOMP-243.
 
 ## [6.0.4](https://github.com/folio-org/stripes-acq-components/tree/v6.0.4) (2025-01-21)
 [Full Changelog](https://github.com/folio-org/stripes-acq-components/compare/v6.0.3...v6.0.4)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Move reusable version history hook useVersionHistoryValueResolvers to the ACQ lib. Refs UISACQCOMP-235.
 * Move reusable claiming code from `ui-receiving` to the shared library. Refs UISACQCOMP-236.
 * Support `CLAIMS` export type in the `useIntegrationConfigs` hook. Refs UISACQCOMP-238.
+* Add `labelless` prop to `FieldTags` component to hide label. Refs UISACQCOMP-243.
 
 ## [6.0.4](https://github.com/folio-org/stripes-acq-components/tree/v6.0.4) (2025-01-21)
 [Full Changelog](https://github.com/folio-org/stripes-acq-components/compare/v6.0.3...v6.0.4)

--- a/lib/FieldTags/FieldTagsContainer.js
+++ b/lib/FieldTags/FieldTagsContainer.js
@@ -20,6 +20,7 @@ const FieldTagsContainer = ({
   mutator,
   name,
   resources,
+  ...props
 }) => {
   const allTags = get(resources, ['tags', 'records'], []);
   const tagSettings = get(resources, ['configTags', 'records'], []);
@@ -46,6 +47,7 @@ const FieldTagsContainer = ({
       marginBottom0={marginBottom0}
       name={name}
       onAdd={onAdd}
+      {...props}
     />
   );
 };

--- a/lib/FieldTags/FieldTagsContainer.js
+++ b/lib/FieldTags/FieldTagsContainer.js
@@ -14,10 +14,12 @@ import FieldTagsFinal from './FieldTagsFinal';
 
 const FieldTagsContainer = ({
   formValues,
+  fullWidth,
+  labelless = false,
+  marginBottom0,
   mutator,
   name,
   resources,
-  labelless = false,
 }) => {
   const allTags = get(resources, ['tags', 'records'], []);
   const tagSettings = get(resources, ['configTags', 'records'], []);
@@ -39,9 +41,11 @@ const FieldTagsContainer = ({
     <FieldTagsFinal
       allTags={allTags}
       formValues={formValues}
+      fullWidth={fullWidth}
+      labelless={labelless}
+      marginBottom0={marginBottom0}
       name={name}
       onAdd={onAdd}
-      labelless={labelless}
     />
   );
 };
@@ -53,8 +57,10 @@ FieldTagsContainer.manifest = Object.freeze({
 
 FieldTagsContainer.propTypes = {
   formValues: PropTypes.object,
-  mutator: PropTypes.object.isRequired,
+  fullWidth: PropTypes.bool,
   labelless: PropTypes.bool,
+  marginBottom0: PropTypes.bool,
+  mutator: PropTypes.object.isRequired,
   name: PropTypes.string.isRequired,
   resources: PropTypes.object.isRequired,
 };

--- a/lib/FieldTags/FieldTagsContainer.js
+++ b/lib/FieldTags/FieldTagsContainer.js
@@ -17,6 +17,7 @@ const FieldTagsContainer = ({
   mutator,
   name,
   resources,
+  labelless = false,
 }) => {
   const allTags = get(resources, ['tags', 'records'], []);
   const tagSettings = get(resources, ['configTags', 'records'], []);
@@ -40,6 +41,7 @@ const FieldTagsContainer = ({
       formValues={formValues}
       name={name}
       onAdd={onAdd}
+      labelless={labelless}
     />
   );
 };
@@ -52,6 +54,7 @@ FieldTagsContainer.manifest = Object.freeze({
 FieldTagsContainer.propTypes = {
   formValues: PropTypes.object,
   mutator: PropTypes.object.isRequired,
+  labelless: PropTypes.bool,
   name: PropTypes.string.isRequired,
   resources: PropTypes.object.isRequired,
 };

--- a/lib/FieldTags/FieldTagsFinal.js
+++ b/lib/FieldTags/FieldTagsFinal.js
@@ -26,9 +26,11 @@ const renderTag = ({ filterValue, exactMatch }) => {
 const FieldTagsFinal = ({
   allTags,
   formValues,
+  fullWidth,
+  labelless = false,
+  marginBottom0,
   name,
   onAdd,
-  labelless = false,
 }) => {
   const { change } = useForm();
   const addTag = useCallback(
@@ -64,8 +66,10 @@ const FieldTagsFinal = ({
       emptyMessage=" "
       filter={filterArrayValues}
       formatter={formatter}
+      fullWidth={fullWidth}
       itemToString={itemToString}
       label={!labelless && label}
+      marginBottom0={marginBottom0}
       name={name}
       validateFields={[]}
     />
@@ -75,7 +79,9 @@ const FieldTagsFinal = ({
 FieldTagsFinal.propTypes = {
   allTags: PropTypes.arrayOf(PropTypes.object),
   formValues: PropTypes.object,
+  fullWidth: PropTypes.bool,
   labelless: PropTypes.bool,
+  marginBottom0: PropTypes.bool,
   name: PropTypes.string.isRequired,
   onAdd: PropTypes.func.isRequired,
 };

--- a/lib/FieldTags/FieldTagsFinal.js
+++ b/lib/FieldTags/FieldTagsFinal.js
@@ -28,6 +28,7 @@ const FieldTagsFinal = ({
   formValues,
   name,
   onAdd,
+  labelless = false,
 }) => {
   const { change } = useForm();
   const addTag = useCallback(
@@ -64,7 +65,7 @@ const FieldTagsFinal = ({
       filter={filterArrayValues}
       formatter={formatter}
       itemToString={itemToString}
-      label={label}
+      label={!labelless && label}
       name={name}
       validateFields={[]}
     />
@@ -74,6 +75,7 @@ const FieldTagsFinal = ({
 FieldTagsFinal.propTypes = {
   allTags: PropTypes.arrayOf(PropTypes.object),
   formValues: PropTypes.object,
+  labelless: PropTypes.bool,
   name: PropTypes.string.isRequired,
   onAdd: PropTypes.func.isRequired,
 };

--- a/lib/FieldTags/FieldTagsFinal.js
+++ b/lib/FieldTags/FieldTagsFinal.js
@@ -31,6 +31,7 @@ const FieldTagsFinal = ({
   marginBottom0,
   name,
   onAdd,
+  ...props
 }) => {
   const { change } = useForm();
   const addTag = useCallback(
@@ -72,6 +73,7 @@ const FieldTagsFinal = ({
       marginBottom0={marginBottom0}
       name={name}
       validateFields={[]}
+      {...props}
     />
   );
 };

--- a/lib/FileUploader/FileUploader.js
+++ b/lib/FileUploader/FileUploader.js
@@ -30,7 +30,10 @@ const FileUploader = ({ onSelectFile }) => {
         ({ getRootProps, getInputProps, open }) => (
           <div {...getRootProps(defaultRootProps)}>
             <div className={css.fileUploader}>
-              <input {...getInputProps()} />
+              <input
+                data-testid="file-uploader-input"
+                {...getInputProps()}
+              />
 
               <div className={css.fileUploaderTitle}>
                 <FormattedMessage id="stripes-acq-components.fileUploader.dropFile" />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-acq-components",
-  "version": "6.0.3",
+  "version": "6.0.4",
   "description": "Component library for Stripes Acquisitions modules",
   "publishConfig": {
     "registry": "https://repository.folio.org/repository/npm-folio/"


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://folio-org.atlassian.net/browse/UISACQCOMP-243

When used in the table there is no need for label to be rendered. 
In current implementation there is no option to hide it.
## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
Introduce labelless prop
<!-- OPTIONAL
#### TODOS and Open Questions
 [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF or video is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
Without labelless prop
![image](https://github.com/user-attachments/assets/d487df6b-cea4-4b27-a25b-d6b43deeb9b2)

With labelless prop
![image](https://github.com/user-attachments/assets/8db9f9c5-b0dc-4343-b7c0-75f056b775a2)

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
