### PR TITLE
STACQCOMP-253: Display Holdings copy number when selecting holding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * *BREAKING* Migrate stripes dependencies to their Sunflower versions. Refs UISACQCOMP-245.
 * *BREAKING* Migrate `react-intl` to v7. Refs UISACQCOMP-246.
 * Include refetch for useOrganization hook. Fixes UISACQCOMP-252.
+* Display Holdings copy number when selecting holding. Refs STACQCOMP-253.
 
 ## [6.0.4](https://github.com/folio-org/stripes-acq-components/tree/v6.0.4) (2025-01-21)
 [Full Changelog](https://github.com/folio-org/stripes-acq-components/compare/v6.0.3...v6.0.4)

--- a/lib/FieldHolding/utils.js
+++ b/lib/FieldHolding/utils.js
@@ -15,7 +15,9 @@ export const getHoldingLocationName = (
   const separator = callNumberLabel || copyNumberLabel ? ' > ' : '';
   const locationName = locationsMap[holding.permanentLocationId]?.name;
 
-  return locationName ? `${locationName}${separator}${callNumberLabel} ${copyNumberLabel}` : invalidReferenceMessage;
+  return locationName
+    ? `${locationName}${separator}${callNumberLabel} ${copyNumberLabel}`.trim()
+    : invalidReferenceMessage;
 };
 
 export const getHoldingOptions = (holdings = [], locationsMap = {}) => (

--- a/lib/FieldHolding/utils.js
+++ b/lib/FieldHolding/utils.js
@@ -11,10 +11,11 @@ export const getHoldingLocationName = (
   invalidReferenceMessage = <FormattedMessage id="stripes-acq-components.invalidReference" />,
 ) => {
   const callNumberLabel = getCallNumber(holding);
-  const separator = callNumberLabel ? ' > ' : '';
+  const copyNumberLabel = holding.copyNumber || '';
+  const separator = callNumberLabel || copyNumberLabel ? ' > ' : '';
   const locationName = locationsMap[holding.permanentLocationId]?.name;
 
-  return locationName ? `${locationName}${separator}${callNumberLabel}` : invalidReferenceMessage;
+  return locationName ? `${locationName}${separator}${callNumberLabel} ${copyNumberLabel}` : invalidReferenceMessage;
 };
 
 export const getHoldingOptions = (holdings = [], locationsMap = {}) => (


### PR DESCRIPTION
## Purpose
* When using the Update Ownership action on an Item, it would be helpful for the Holdings dropdown in the resulting modal to include Copy Number for a given holdings. The reason being that sometimes a library will have multiple holdings with matching Location and Call Number. Displaying the call number would help users differentiate between such Holdings and aid in choosing the correctly for their given scenario.

## Refs
[STACQCOMP-253](https://folio-org.atlassian.net/browse/UISACQCOMP-253)

## Screenshots

### Before
![image](https://github.com/user-attachments/assets/1db13af6-73bd-4bba-b0ad-423788a1c181)

### After
![image](https://github.com/user-attachments/assets/a2dbba59-1a56-414f-91b6-4be98c2631f9)


## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
