### PR TITLE
UISACQCOMP-258 make FieldAutoSuggest::includeItem() null-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## (7.1.0 IN PROGRESS)
 
+* Make `FieldAutoSuggest::includeItem()` null-safe. Refs UISACQCOMP-258.
+
 ## [7.0.1](https://github.com/folio-org/stripes-acq-components/tree/v7.0.1) (2025-03-24)
 [Full Changelog](https://github.com/folio-org/stripes-acq-components/compare/v7.0.0...v7.0.1)
 

--- a/lib/FieldAutoSuggest/FieldAutoSuggest.js
+++ b/lib/FieldAutoSuggest/FieldAutoSuggest.js
@@ -5,6 +5,8 @@ import { Field } from 'redux-form';
 
 import { AutoSuggest } from '@folio/stripes/components';
 
+export const includeItem = (item, valueKey, searchString) => !!item?.[valueKey]?.includes(searchString);
+
 const FieldAutoSuggest = ({ fieldComponent, labelId, valueKey, ...rest }) => {
   const FieldComponent = fieldComponent || Field;
 
@@ -13,7 +15,7 @@ const FieldAutoSuggest = ({ fieldComponent, labelId, valueKey, ...rest }) => {
       component={AutoSuggest}
       label={<FormattedMessage id={labelId} />}
       valueKey={valueKey}
-      includeItem={(item, searchString) => item[valueKey].includes(searchString)}
+      includeItem={includeItem}
       renderOption={item => (item ? item[valueKey] : '')}
       renderValue={item => (item ? item[valueKey] : '')}
       {...rest}

--- a/lib/FieldAutoSuggest/FieldAutoSuggest.test.js
+++ b/lib/FieldAutoSuggest/FieldAutoSuggest.test.js
@@ -1,0 +1,22 @@
+import { includeItem } from './FieldAutoSuggest';
+
+describe('FieldAutoSuggest', () => {
+  describe('includeItem', () => {
+    it('returns true when item[valueKey] contains search string', () => {
+      // now you, too, will hear hoMEOWner in your head every time you read it
+      expect(includeItem({ aMinor: 'homeowner' }, 'aMinor', 'meow')).toBe(true);
+    });
+
+    describe('returns false', () => {
+      it('when item[valueKey] does not contain search string', () => {
+        expect(includeItem({ aMinor: 'homeowner' }, 'aMinor', 'woof')).toBe(false);
+      });
+      it('when item[valueKey] is undefined', () => {
+        expect(includeItem({ nothing: 'gourmet' }, 'aMinor', 'toothpaste')).toBe(false);
+      });
+      it('when item is undefined', () => {
+        expect(includeItem(null, 'aMinor', 'toothpaste')).toBe(false);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Avoid NPEs in `includeItem()` if the item itself is null or if the requested field does not exist.

Refs [UISACQCOMP-258](https://folio-org.atlassian.net/browse/UISACQCOMP-258)
