### PR TITLE
UISACQCOMP-262 Enhance `CentralOrderingContextProvider` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,6 @@
 
 * Support tenantId in `useClaimsSend` and `usePiecesStatusBatchUpdate` hooks. Refs UISACQCOMP-256.
 
-## [7.0.1](https://github.com/folio-org/stripes-acq-components/tree/v7.0.1) (2025-03-24)
-[Full Changelog](https://github.com/folio-org/stripes-acq-components/compare/v7.0.0...v7.0.1)
-
-* Support tenantId in `useClaimsSend` and `usePiecesStatusBatchUpdate` hooks. Refs UISACQCOMP-256.
-
 ## [7.0.0](https://github.com/folio-org/stripes-acq-components/tree/v7.0.0) (2025-03-11)
 [Full Changelog](https://github.com/folio-org/stripes-acq-components/compare/v6.0.4...v7.0.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Support for restriction on assigned affiliations. Refs UISACQCOMP-257.
 * Create components to support exchange rate source feature. Refs UISACQCOMP-259.
+* Enhance `CentralOrderingContextProvider` component. Refs UISACQCOMP-262.
 
 ## [7.0.3](https://github.com/folio-org/stripes-acq-components/tree/v7.0.3) (2025-03-31)
 [Full Changelog](https://github.com/folio-org/stripes-acq-components/compare/v7.0.2...v7.0.3)

--- a/lib/contexts/CentralOrderingContext.js
+++ b/lib/contexts/CentralOrderingContext.js
@@ -19,6 +19,7 @@ export const useCentralOrderingContext = () => useContext(CentralOrderingContext
 export const CentralOrderingContextProvider = ({
   centralTenantOnly = false,
   children,
+  throwOnError = false,
 }) => {
   const stripes = useStripes();
   const isUserInCentralTenant = checkIfUserInCentralTenant(stripes);
@@ -26,6 +27,7 @@ export const CentralOrderingContextProvider = ({
   const { enabled } = useCentralOrderingSettings({
     enabled: centralTenantOnly ? isUserInCentralTenant : true,
     suspense: true,
+    useErrorBoundary: throwOnError,
   });
 
   const value = useMemo(() => ({
@@ -42,4 +44,5 @@ export const CentralOrderingContextProvider = ({
 CentralOrderingContextProvider.propTypes = {
   centralTenantOnly: PropTypes.bool,
   children: PropTypes.node,
+  throwOnError: PropTypes.bool,
 };

--- a/lib/contexts/CentralOrderingContext.js
+++ b/lib/contexts/CentralOrderingContext.js
@@ -19,6 +19,7 @@ export const useCentralOrderingContext = () => useContext(CentralOrderingContext
 export const CentralOrderingContextProvider = ({
   centralTenantOnly = false,
   children,
+  suspense = true,
   throwOnError = false,
 }) => {
   const stripes = useStripes();
@@ -26,7 +27,8 @@ export const CentralOrderingContextProvider = ({
 
   const { enabled } = useCentralOrderingSettings({
     enabled: centralTenantOnly ? isUserInCentralTenant : true,
-    suspense: true,
+    queryKey: ['central-ordering-settings'],
+    suspense,
     useErrorBoundary: throwOnError,
   });
 
@@ -44,5 +46,6 @@ export const CentralOrderingContextProvider = ({
 CentralOrderingContextProvider.propTypes = {
   centralTenantOnly: PropTypes.bool,
   children: PropTypes.node,
+  suspense: PropTypes.bool,
   throwOnError: PropTypes.bool,
 };

--- a/lib/contexts/CentralOrderingContext.js
+++ b/lib/contexts/CentralOrderingContext.js
@@ -12,6 +12,8 @@ import {
 
 import { useCentralOrderingSettings } from '../hooks';
 
+const QUERY_KEY = 'central-ordering-context';
+
 export const CentralOrderingContext = createContext();
 
 export const useCentralOrderingContext = () => useContext(CentralOrderingContext);
@@ -27,7 +29,7 @@ export const CentralOrderingContextProvider = ({
 
   const { enabled } = useCentralOrderingSettings({
     enabled: centralTenantOnly ? isUserInCentralTenant : true,
-    queryKey: ['central-ordering-settings'],
+    queryKey: [QUERY_KEY],
     suspense,
     useErrorBoundary: throwOnError,
   });


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://folio-org.atlassian.net/browse/UISACQCOMP-262

An error in getting central ordering settings should not be propagated to the error boundary and crash the app. Instead, the app should consider that central ordering is disabled and work normally.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Provide a specific query key to the `useCentralOrderingSettings` hook;
- Provide `throwOnError` prop to make it possible to throw error to the "ErrorBoundary" if needed;
- Provide `suspense` prop.

<!-- OPTIONAL
#### TODOS and Open Questions
 [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
