### PR TITLE
UISACQCOMP-259 Fix render without required perm

### DIFF
--- a/lib/Credentials/CredentialsContext.js
+++ b/lib/Credentials/CredentialsContext.js
@@ -7,10 +7,7 @@ import {
 import { FormattedMessage } from 'react-intl';
 
 import { Button } from '@folio/stripes/components';
-import {
-  IfPermission,
-  useStripes,
-} from '@folio/stripes/core';
+import { useStripes } from '@folio/stripes/core';
 
 import { useToggle } from '../hooks';
 
@@ -34,7 +31,7 @@ export const CredentialsProvider = ({
   const isPermitted = perm ? stripes.hasPerm(perm) : true;
 
   const renderToggle = useCallback((btnProps = {}) => (
-    <IfPermission perm={perm}>
+    isPermitted && (
       <div className={css.toggle}>
         <Button
           onClick={toggleCredentials}
@@ -43,8 +40,8 @@ export const CredentialsProvider = ({
           {isCredentialsVisible ? hideCredentialsLabel : showCredentialsLabel}
         </Button>
       </div>
-    </IfPermission>
-  ), [hideCredentialsLabel, isCredentialsVisible, perm, showCredentialsLabel, toggleCredentials]);
+    )
+  ), [hideCredentialsLabel, isCredentialsVisible, isPermitted, showCredentialsLabel, toggleCredentials]);
 
   const contextValue = useMemo(() => ({
     isCredentialsVisible,
@@ -69,6 +66,6 @@ CredentialsProvider.propTypes = {
   ]),
   hideCredentialsLabel: PropTypes.node,
   isKeyValue: PropTypes.bool,
-  perm: PropTypes.string.isRequired,
+  perm: PropTypes.string,
   showCredentialsLabel: PropTypes.node,
 };


### PR DESCRIPTION
## Purpose

https://folio-org.atlassian.net/browse/UISACQCOMP-259

The `<IfPermission>` component requires a mandatory `perm` prop. However, the current implementation of "credentials" components allows usage without explicitly passing permissions, which leads to an error when `perm` is missing.  
This PR adds a check to ensure `perm` is present before rendering `<IfPermission>`, preventing runtime errors.
