### PR TITLE
UISACQCOMP-278 `useLocationFilters` - allow applying filters without writing values to the url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Increase the limit for the funds query. Refs UISACQCOMP-275.
 * Retrieve form values in the handler function to get relevant data. Fixes UISACQCOMP-276.
 * Refactor `FieldTags` component to use `react-query`. Refs UISACQCOMP-277.
+* `useLocationFilters` - allow applying filters without writing values to the url. Refs UISACQCOMP-278.
 
 ## [7.0.5](https://github.com/folio-org/stripes-acq-components/tree/v7.0.5) (2025-05-06)
 [Full Changelog](https://github.com/folio-org/stripes-acq-components/compare/v7.0.4...v7.0.5)

--- a/lib/AcqList/hooks/useLocationFilters.js
+++ b/lib/AcqList/hooks/useLocationFilters.js
@@ -66,13 +66,15 @@ const useLocationFilters = (
   );
 
   const applyLocationFilters = useCallback(
-    (type, value) => {
+    (type, value, updateURL = true) => {
       const newFilters = applyFilters(type, value);
 
-      history.push({
-        pathname: '',
-        search: `${buildSearch(newFilters, location.search)}`,
-      });
+      if (updateURL) {
+        history.push({
+          pathname: '',
+          search: `${buildSearch(newFilters, location.search)}`,
+        });
+      }
 
       return newFilters;
     },


### PR DESCRIPTION
## Description
In some cases we may want to apply some default filter values, but not write them to the url which would trigger a search

## Issues
[UISACQCOMP-278](https://folio-org.atlassian.net/browse/UISACQCOMP-278)