### PR TITLE
UISACQCOMP-300 Update CQL builder to support new indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [7.2.0](IN PROGRESS)
 
+* Update CQL Builder to support new indices. Refs UISACQCOMP-300.
+
 ## [7.1.0](https://github.com/folio-org/stripes-acq-components/tree/v7.1.0) (2026-04-15)
 [Full Changelog](https://github.com/folio-org/stripes-acq-components/compare/v7.0.5...v7.1.0)
 

--- a/lib/AcqList/SingleSearchForm/SingleSearchForm.js
+++ b/lib/AcqList/SingleSearchForm/SingleSearchForm.js
@@ -24,6 +24,7 @@ const SingleSearchForm = ({
   changeSearch,
   changeSearchIndex,
   disabled = false,
+  error,
   indexRef,
   inputRef,
   inputType,
@@ -88,6 +89,7 @@ const SingleSearchForm = ({
         ariaLabel={ariaLabel}
         autoFocus={autoFocus}
         className={css.searchField}
+        error={error}
         value={searchQuery}
         id="input-record-search"
         loading={isLoading}
@@ -127,6 +129,7 @@ SingleSearchForm.propTypes = {
   changeSearch: PropTypes.func.isRequired,
   changeSearchIndex: PropTypes.func,
   disabled: PropTypes.bool,
+  error: PropTypes.node,
   indexRef: PropTypes.oneOfType([
     PropTypes.func,
     PropTypes.shape({ current: PropTypes.instanceOf(Element) }),

--- a/lib/AcqList/utils/queryUtils.js
+++ b/lib/AcqList/utils/queryUtils.js
@@ -28,7 +28,7 @@ const {
 } = CQLBuilder.OPERATORS;
 
 /**
- * Builds a CQL query for multi-selection filters. If the filter value is an array, it constructs a query that checks if the field matches any of the values using "or".
+ * Builds a CQL query for filters with multiple options. If the filter value is an array, it constructs a query that checks if the field matches any of the values using "or".
  * If it's a single value, it constructs a simple equality query.
  * Different from buildArrayFieldQuery, this function does not add wildcards around the values.
  * It also supports adding modifiers to the query if provided in the options.
@@ -41,7 +41,7 @@ const {
  * @param {object|string[]} options.modifiers - Modifiers to apply: object for AND-style (`{ type: 'book' }` → `/@type=book`), array for OR-style (`['author']` → `/@author`)
  * @returns {string} The constructed CQL query string
  */
-export const buildMultiSelectionCqlQuery = (filterKey, filterValue, options = {}) => {
+export const buildMultiOptionCqlQuery = (filterKey, filterValue, options = {}) => {
   const {
     operator = FUZZY,
     modifiers,

--- a/lib/AcqList/utils/queryUtils.js
+++ b/lib/AcqList/utils/queryUtils.js
@@ -8,6 +8,10 @@ import { escapeCqlValue } from '@folio/stripes/util';
 
 import { emptyArrayFilterValue } from '../../constants';
 import {
+  CQLBuilder,
+  CQLBuilderArrayValue,
+} from '../../utils';
+import {
   SEARCH_PARAMETER,
   OFFSET_PARAMETER,
   LIMIT_PARAMETER,
@@ -17,6 +21,43 @@ import {
   SEARCH_INDEX_PARAMETER,
   DATE_RANGE_FILTER_FORMAT,
 } from '../constants';
+
+const {
+  EQUAL,
+  FUZZY,
+} = CQLBuilder.OPERATORS;
+
+/**
+ * Builds a CQL query for multi-selection filters. If the filter value is an array, it constructs a query that checks if the field matches any of the values using "or".
+ * If it's a single value, it constructs a simple equality query.
+ * Different from buildArrayFieldQuery, this function does not add wildcards around the values.
+ * It also supports adding modifiers to the query if provided in the options.
+ * Uses CQLBuilder for constructing the query, which allows for more complex queries and proper escaping of values.
+ *
+ * @param {string} filterKey - The key of the filter (CQL index)
+ * @param {string|string[]} filterValue - The value(s) of the filter
+ * @param {object} options - Additional options for query building
+ * @param {string} options.operator - The CQL operator to use (default is FUZZY)
+ * @param {object|string[]} options.modifiers - Modifiers to apply: object for AND-style (`{ type: 'book' }` → `/@type=book`), array for OR-style (`['author']` → `/@author`)
+ * @returns {string} The constructed CQL query string
+ */
+export const buildMultiSelectionCqlQuery = (filterKey, filterValue, options = {}) => {
+  const {
+    operator = FUZZY,
+    modifiers,
+  } = options;
+  const cql = new CQLBuilder();
+
+  const value = Array.isArray(filterValue) ? new CQLBuilderArrayValue(filterValue) : filterValue;
+  const isEmptyArrayValue = value === emptyArrayFilterValue;
+  const relation = isEmptyArrayValue ? EQUAL : operator;
+
+  return cql
+    .index(filterKey)
+    .relation(relation, !isEmptyArrayValue && modifiers)
+    .value(value)
+    .build();
+};
 
 export const buildArrayFieldQuery = (filterKey, filterValue, _options = {}) => {
   if (Array.isArray(filterValue)) {

--- a/lib/AcqList/utils/queryUtils.js
+++ b/lib/AcqList/utils/queryUtils.js
@@ -37,8 +37,8 @@ const {
  * @param {string} filterKey - The key of the filter (CQL index)
  * @param {string|string[]} filterValue - The value(s) of the filter
  * @param {object} options - Additional options for query building
- * @param {string} options.operator - The CQL operator to use (default is FUZZY)
- * @param {object|string[]} options.modifiers - Modifiers to apply: object for AND-style (`{ type: 'book' }` → `/@type=book`), array for OR-style (`['author']` → `/@author`)
+ * @param {string} options.operator - The CQL operator to use (default is '=')
+ * @param {object[]} options.modifiers - Modifiers to apply: object for AND-style (`{ type: 'book' }` → `/@type=book`), array for OR-style (`['author']` → `/@author`)
  * @returns {string} The constructed CQL query string
  */
 export const buildMultiOptionCqlQuery = (filterKey, filterValue, options = {}) => {

--- a/lib/AcqList/utils/queryUtils.js
+++ b/lib/AcqList/utils/queryUtils.js
@@ -54,7 +54,7 @@ export const buildMultiOptionCqlQuery = (filterKey, filterValue, options = {}) =
 
   return cql
     .index(filterKey)
-    .relation(relation, !isEmptyArrayValue && modifiers)
+    .relation(relation, isEmptyArrayValue ? undefined : modifiers)
     .value(value)
     .build();
 };

--- a/lib/AcqList/utils/queryUtils.test.js
+++ b/lib/AcqList/utils/queryUtils.test.js
@@ -143,7 +143,7 @@ describe('queryUtils', () => {
     it.each([
       ['single string value', 'book', 'field="book"'],
       ['array of values', ['book', 'magazine'], 'field=("book" OR "magazine")'],
-      ['single-element array', ['only'], 'field=("only")'],
+      ['single-element array', ['only'], 'field="only"'],
     ])('should build a fuzzy (=) query for a %s', (_, value, expected) => {
       expect(queryUtils.buildMultiOptionCqlQuery('field', value)).toBe(expected);
     });

--- a/lib/AcqList/utils/queryUtils.test.js
+++ b/lib/AcqList/utils/queryUtils.test.js
@@ -138,4 +138,53 @@ describe('queryUtils', () => {
         .toEqual(`${String.raw`(("he\\o wor\d") and good=="mood")`} ${defaultSorting}`);
     });
   });
+
+  describe('buildMultiOptionCqlQuery', () => {
+    it.each([
+      ['single string value', 'book', 'field="book"'],
+      ['array of values', ['book', 'magazine'], 'field=("book" OR "magazine")'],
+      ['single-element array', ['only'], 'field=("only")'],
+    ])('should build a fuzzy (=) query for a %s', (_, value, expected) => {
+      expect(queryUtils.buildMultiOptionCqlQuery('field', value)).toBe(expected);
+    });
+
+    it.each([
+      ['no options', undefined],
+      ['modifiers option', { modifiers: [{ name: '@type', value: 'Rush' }] }],
+      ['custom operator option', { operator: '=' }],
+    ])('should force == and ignore %s when value is the empty-array sentinel', (_, options) => {
+      expect(queryUtils.buildMultiOptionCqlQuery('field', '[]', options)).toBe('field=="[]"');
+    });
+
+    it('should use a custom operator when provided', () => {
+      expect(queryUtils.buildMultiOptionCqlQuery('field', 'book', { operator: '==' }))
+        .toBe('field=="book"');
+    });
+
+    describe('relation modifiers', () => {
+      it.each([
+        ['with a value', { name: '@type', value: 'Rush' }, 'field =/@type=Rush "book"'],
+        ['without a value (flag-style)', { name: '@author' }, 'field =/@author "book"'],
+      ])('should apply a single relation modifier %s to a string value', (_, modifier, expected) => {
+        expect(queryUtils.buildMultiOptionCqlQuery('field', 'book', { modifiers: [modifier] })).toBe(expected);
+      });
+
+      it('should apply a modifier when value is an array', () => {
+        expect(
+          queryUtils.buildMultiOptionCqlQuery('field', ['book', 'magazine'], { modifiers: [{ name: '@type', value: 'Rush' }] }),
+        ).toBe('field =/@type=Rush ("book" OR "magazine")');
+      });
+
+      it('should apply multiple relation modifiers in order', () => {
+        expect(
+          queryUtils.buildMultiOptionCqlQuery('field', 'book', {
+            modifiers: [
+              { name: '@type', value: 'Rush' },
+              { name: '@status', value: 'Open' },
+            ],
+          }),
+        ).toBe('field =/@type=Rush/@status=Open "book"');
+      });
+    });
+  });
 });

--- a/lib/constants/constants.js
+++ b/lib/constants/constants.js
@@ -19,7 +19,7 @@ export const ERROR_CODE_CONFLICT = 'conflict';
 export const DICT_IDENTIFIER_TYPES = 'identifierTypes';
 export const DICT_CONTRIBUTOR_NAME_TYPES = 'contributorNameTypes';
 
-export const emptyArrayFilterValue = '/respectAccents []';
+export const emptyArrayFilterValue = '[]';
 
 export const CUSTOM_FIELDS = 'customFields';
 

--- a/lib/hooks/consortia/useCentralOrderingSettings/useCentralOrderingSettings.js
+++ b/lib/hooks/consortia/useCentralOrderingSettings/useCentralOrderingSettings.js
@@ -10,7 +10,10 @@ import {
   CENTRAL_ORDERING_SETTINGS_KEY,
   ORDERS_STORAGE_SETTINGS_API,
 } from '../../../constants';
-import { getConsortiumCentralTenantId } from '../../../utils';
+import {
+  CQLBuilder,
+  getConsortiumCentralTenantId,
+} from '../../../utils';
 
 export const useCentralOrderingSettings = (options = {}) => {
   const stripes = useStripes();
@@ -27,7 +30,7 @@ export const useCentralOrderingSettings = (options = {}) => {
 
   const searchParams = {
     limit: 1,
-    query: `key=${CENTRAL_ORDERING_SETTINGS_KEY}`,
+    query: new CQLBuilder().equal('key', CENTRAL_ORDERING_SETTINGS_KEY).build(),
   };
 
   const {

--- a/lib/hooks/useDefaultReceivingSearchSettings/useDefaultReceivingSearchSettings.js
+++ b/lib/hooks/useDefaultReceivingSearchSettings/useDefaultReceivingSearchSettings.js
@@ -9,6 +9,7 @@ import {
   CENTRAL_ORDERING_DEFAULT_RECEIVING_SEARCH_SETTINGS_KEY,
   ORDERS_STORAGE_SETTINGS_API,
 } from '../../constants';
+import { CQLBuilder } from '../../utils';
 
 export const useDefaultReceivingSearchSettings = (options = {}) => {
   const ky = useOkapiKy();
@@ -16,7 +17,7 @@ export const useDefaultReceivingSearchSettings = (options = {}) => {
 
   const searchParams = {
     limit: 1,
-    query: `key=${CENTRAL_ORDERING_DEFAULT_RECEIVING_SEARCH_SETTINGS_KEY}`,
+    query: new CQLBuilder().equal('key', CENTRAL_ORDERING_DEFAULT_RECEIVING_SEARCH_SETTINGS_KEY).build(),
   };
 
   const {

--- a/lib/utils/CQLBuilder/CQLBuilder.js
+++ b/lib/utils/CQLBuilder/CQLBuilder.js
@@ -1,6 +1,7 @@
-import identity from 'lodash/identity';
-
-import { escapeCqlValue } from '@folio/stripes/util';
+import {
+  CQLBuilderArrayValue,
+  CQLBuilderStringValue,
+} from './value-formatters';
 
 /**
  * Complete CQL Query Builder supporting CQL 1.2 features
@@ -40,6 +41,17 @@ export class CQLBuilder {
     OPEN: '(',
     CLOSE: ')',
   };
+
+  static VALUE_FORMATTERS = [
+    {
+      selector: (v) => Array.isArray(v),
+      format: (v, opts) => new CQLBuilderArrayValue(v, opts).toCQL(),
+    },
+    {
+      selector: (v) => typeof v === 'string',
+      format: (v, opts) => new CQLBuilderStringValue(v, opts).toCQL(),
+    },
+  ];
 
   constructor() {
     this.queryParts = [];
@@ -561,6 +573,7 @@ export class CQLBuilder {
     this.queryParts = [];
     this.requiresImplicitAnd = false;
     this.scopedIndex = null;
+    this.currentRelationModifiers = [];
     this.currentBooleanModifiers = [];
   }
 
@@ -607,22 +620,10 @@ export class CQLBuilder {
       return options.formatter(value);
     }
 
-    return typeof value === 'string' ? `"${this._getEscapedValue(value, options)}"` : value;
-  }
+    const { format } = CQLBuilder.VALUE_FORMATTERS.find(({ selector }) => selector(value)) ?? {};
 
-  /**
-   * Escape special characters for CQL
-   * @private
-   * @param {string} value - The value to escape
-   * @param {Object} [options] - Optional parameters for the condition
-   * @param {boolean} [options.escapeCQL] - Whether to escape special CQL characters (`"` or `\`") in the value
-   * @returns {string} Either an escaped string or initial value when `escapeCQL` option is `false`
-   */
-  _getEscapedValue(value, options = {}) {
-    const { escapeCQL = true } = options;
-
-    const escapeFn = escapeCQL ? escapeCqlValue : identity;
-
-    return escapeFn(value);
+    return format
+      ? format(value, { escapeCQL: options.escapeCQL })
+      : value;
   }
 }

--- a/lib/utils/CQLBuilder/CQLBuilder.js
+++ b/lib/utils/CQLBuilder/CQLBuilder.js
@@ -41,14 +41,11 @@ export class CQLBuilder {
     CLOSE: ')',
   };
 
-  static AT_MODIFIER_PREFIX = '/@';
-
   constructor() {
-    // Stores all parts of the query in sequence (terms, operators, modifiers)
     this.queryParts = [];
-    // Holds modifiers that will be applied to the next condition
-    this.currentModifiers = {};
     this.requiresImplicitAnd = false;
+    this.currentRelationModifiers = [];
+    this.currentBooleanModifiers = [];
   }
 
   // ===== BASIC CLAUSES =====
@@ -67,15 +64,25 @@ export class CQLBuilder {
   /**
    * Sets the comparison operator for scoped operations
    * @param {string} operator - The operator (=, ==, >, <, all, any, etc.)
+   * @param {Array<{name: string, value?: any}>} [modifiers] - Optional inline relation modifiers.
+   *   Merged with any modifiers queued via {@link relationModifier} (inline modifiers applied first).
    * @returns {CQLBuilder} Returns self for method chaining
    * @throws {Error} If no index was set before calling relation()
    */
-  relation(operator) {
+  relation(operator, modifiers) {
     if (!this.scopedIndex) {
       throw new Error('Index must be set before relation');
     }
 
-    this.queryParts.push(`${this.scopedIndex} ${operator}`);
+    if (modifiers) {
+      this.currentRelationModifiers.unshift(
+        ...modifiers.map(m => (m.value === undefined ? m.name : `${m.name}=${m.value}`)),
+      );
+    }
+
+    const relationModifiersChain = this._buildRelationModifiers();
+
+    this.queryParts.push(`${this.scopedIndex} ${operator}${relationModifiersChain}`);
     this.scopedIndex = null;
 
     return this;
@@ -90,16 +97,15 @@ export class CQLBuilder {
    * @throws {Error} If value doesn't follow a relation
    */
   value(value, options) {
-    const lastPart = this.queryParts[this.queryParts.length - 1];
+    const lastPart = this.queryParts.at(-1);
 
     if (typeof lastPart !== 'string' || !lastPart.includes(' ')) {
       throw new Error('Value must follow a relation');
     }
 
-    const quotedValue = typeof value === 'string' ? `"${this._getEscapedValue(value, options)}"` : value;
+    const formattedValue = this._formatValue(value, options);
 
-    this.queryParts[this.queryParts.length - 1] = `${lastPart} ${quotedValue}`;
-    this._applyModifiers();
+    this.queryParts[this.queryParts.length - 1] = `${lastPart} ${formattedValue}`;
     this.requiresImplicitAnd = true;
 
     return this;
@@ -113,6 +119,7 @@ export class CQLBuilder {
    * @param {string|number} value - The exact value to match
    * @param {Object} [options] - Optional parameters for the condition
    * @param {boolean} [options.escapeCQL] - Whether to escape special CQL characters (`"` or `\`") in the value
+   * @param {Array<{name: string, value?: any}>} [options.modifiers] - Inline relation modifiers
    * @returns {CQLBuilder} Returns self for method chaining
    */
   equal(field, value, options) {
@@ -125,6 +132,7 @@ export class CQLBuilder {
    * @param {string} value - The search pattern (can include *)
    * @param {Object} [options] - Optional parameters for the condition
    * @param {boolean} [options.escapeCQL] - Whether to escape special CQL characters (`"` or `\`") in the value
+   * @param {Array<{name: string, value?: any}>} [options.modifiers] - Inline relation modifiers
    * @returns {CQLBuilder} Returns self for method chaining
    */
   fuzzy(field, value, options) {
@@ -137,6 +145,7 @@ export class CQLBuilder {
    * @param {string|number} value - The value to compare against
    * @param {Object} [options] - Optional parameters for the condition
    * @param {boolean} [options.escapeCQL] - Whether to escape special CQL characters (`"` or `\`") in the value
+   * @param {Array<{name: string, value?: any}>} [options.modifiers] - Inline relation modifiers
    * @returns {CQLBuilder} Returns self for method chaining
    */
   notEqual(field, value, options) {
@@ -149,6 +158,7 @@ export class CQLBuilder {
    * @param {string|number} value - The value to compare against
    * @param {Object} [options] - Optional parameters for the condition
    * @param {boolean} [options.escapeCQL] - Whether to escape special CQL characters (`"` or `\`") in the value
+   * @param {Array<{name: string, value?: any}>} [options.modifiers] - Inline relation modifiers
    * @returns {CQLBuilder} Returns self for method chaining
    */
   greaterThan(field, value, options) {
@@ -161,13 +171,16 @@ export class CQLBuilder {
    * @param {string|number} value - The value to compare against
    * @param {Object} [options] - Optional parameters for the condition
    * @param {boolean} [options.escapeCQL] - Whether to escape special CQL characters (`"` or `\`") in the value
+   * @param {Array<{name: string, value?: any}>} [options.modifiers] - Inline relation modifiers
    * @returns {CQLBuilder} Returns self for method chaining
    */
   greaterThanEqual(field, value, options) {
     return this._addCondition(field, CQLBuilder.OPERATORS.GREATER_THAN_EQUAL, value, options);
   }
 
-  /* Shorthand for greaterThanEqual */
+  /**
+   * Shorthand for {@link greaterThanEqual}
+   */
   gte(field, value, options) {
     return this.greaterThanEqual(field, value, options);
   }
@@ -178,6 +191,7 @@ export class CQLBuilder {
    * @param {string|number} value - The value to compare against
    * @param {Object} [options] - Optional parameters for the condition
    * @param {boolean} [options.escapeCQL] - Whether to escape special CQL characters (`"` or `\`") in the value
+   * @param {Array<{name: string, value?: any}>} [options.modifiers] - Inline relation modifiers
    * @returns {CQLBuilder} Returns self for method chaining
    */
   lessThan(field, value, options) {
@@ -190,13 +204,16 @@ export class CQLBuilder {
    * @param {string|number} value - The value to compare against
    * @param {Object} [options] - Optional parameters for the condition
    * @param {boolean} [options.escapeCQL] - Whether to escape special CQL characters (`"` or `\`") in the value
+   * @param {Array<{name: string, value?: any}>} [options.modifiers] - Inline relation modifiers
    * @returns {CQLBuilder} Returns self for method chaining
    */
   lessThanEqual(field, value, options) {
     return this._addCondition(field, CQLBuilder.OPERATORS.LESS_THAN_EQUAL, value, options);
   }
 
-  /** Shorthand for lessThanEqual */
+  /**
+   * Shorthand for {@link lessThanEqual}
+   */
   lte(field, value, options) {
     return this.lessThanEqual(field, value, options);
   }
@@ -207,6 +224,7 @@ export class CQLBuilder {
    * @param {string} value - Space-separated words to find
    * @param {Object} [options] - Optional parameters for the condition
    * @param {boolean} [options.escapeCQL] - Whether to escape special CQL characters (`"` or `\`") in the value
+   * @param {Array<{name: string, value?: any}>} [options.modifiers] - Inline relation modifiers
    * @returns {CQLBuilder} Returns self for method chaining
    */
   contains(field, value, options) {
@@ -214,41 +232,75 @@ export class CQLBuilder {
   }
 
   /**
-   * Contains any term (any operator)
+   * Adds a contains-any-term condition (any operator)
+   * @param {string} field - The field name to search
+   * @param {string} value - Space-separated terms, at least one of which must be present
+   * @param {Object} [options] - Optional parameters for the condition
+   * @param {boolean} [options.escapeCQL] - Whether to escape special CQL characters (`"` or `\`") in the value
+   * @param {Array<{name: string, value?: any}>} [options.modifiers] - Inline relation modifiers
+   * @returns {CQLBuilder} Returns self for method chaining
    */
   containsAny(field, value, options) {
     return this._addCondition(field, CQLBuilder.OPERATORS.ANY, value, options);
   }
 
+  /**
+   * Adds a match-all clause (cql.allRecords=1)
+   * @returns {CQLBuilder} Returns self for method chaining
+   */
   allRecords(options) {
     return this.fuzzy(CQLBuilder.SPECIAL_TERMS.ALL_RECORDS, 1, options);
   }
 
   // ===== BOOLEAN OPERATORS =====
+
+  /**
+   * Inserts an AND operator between the current and next clause.
+   * Consumes any modifiers queued via {@link booleanModifier} / {@link booleanModifiers}.
+   * No-op when there is no left-hand clause or when a boolean operator is already pending.
+   * @returns {CQLBuilder} Returns self for method chaining
+   */
   and() {
     if (this.queryParts.length === 0 || this._lastPartIsOperator()) {
       return this;
     }
 
-    this.queryParts.push(CQLBuilder.OPERATORS.AND);
+    const modChain = this._serializeBooleanModifiers(this._consumePendingBooleanModifiers());
+
+    this.queryParts.push(`${CQLBuilder.OPERATORS.AND}${modChain}`);
     this.requiresImplicitAnd = false;
 
     return this;
   }
 
+  /**
+   * Inserts an OR operator between the current and next clause.
+   * Consumes any modifiers queued via {@link booleanModifier} / {@link booleanModifiers}.
+   * No-op when there is no left-hand clause or when a boolean operator is already pending.
+   * @returns {CQLBuilder} Returns self for method chaining
+   */
   or() {
     if (this.queryParts.length === 0 || this._lastPartIsOperator()) {
       return this;
     }
 
-    this.queryParts.push(CQLBuilder.OPERATORS.OR);
+    const modChain = this._serializeBooleanModifiers(this._consumePendingBooleanModifiers());
+
+    this.queryParts.push(`${CQLBuilder.OPERATORS.OR}${modChain}`);
     this.requiresImplicitAnd = false;
 
     return this;
   }
 
+  /**
+   * Inserts a NOT operator before the next clause.
+   * Consumes any modifiers queued via {@link booleanModifier} / {@link booleanModifiers}.
+   * @returns {CQLBuilder} Returns self for method chaining
+   */
   not() {
-    this.queryParts.push(CQLBuilder.OPERATORS.NOT);
+    const modChain = this._serializeBooleanModifiers(this._consumePendingBooleanModifiers());
+
+    this.queryParts.push(`${CQLBuilder.OPERATORS.NOT}${modChain}`);
 
     return this;
   }
@@ -256,67 +308,21 @@ export class CQLBuilder {
   // ===== PROXIMITY SEARCH =====
 
   /**
-   * Proximity search
-   * @param {number} distance - Maximum distance between terms
-   * @param {string} [unit=word] - Proximity unit (word, sentence, paragraph)
+   * Proximity operator between two terms.
+   * @param {Array<{name: string, value?: any, symbol?: string}>} [modifiers] - Optional boolean modifiers.
+   *   Each entry serializes as /name, /name=value, or /name<symbol>value.
    * @returns {CQLBuilder}
    */
-  prox(distance, unit = 'word') {
-    this.queryParts.push(`prox/${unit}/${distance}`);
-
-    return this;
-  }
-
-  // ===== ARRAY SEARCH MODIFIERS =====
-
-  /**
-   * AND-style array search with value modifiers
-   * @param {string} field - Array field name
-   * @param {Object} modifiers - Key-value modifier pairs
-   * @param {string|number} searchValue - Value to search for
-   * @param {Object} [options] - Optional parameters for the condition
-   * @param {boolean} [options.escapeCQL] - Whether to escape special CQL characters (`"` or `\`") in the value
-   * @returns {CQLBuilder}
-   */
-  andModifiersSearch(field, modifiers, searchValue, options = {}) {
-    if (this._shouldAddImplicitAnd()) {
-      this.queryParts.push(CQLBuilder.OPERATORS.AND);
+  prox(modifiers) {
+    if (this.queryParts.length === 0 || this._lastPartIsOperator()) {
+      return this;
     }
 
-    const modifiersChain = Object.entries(modifiers)
-      .map(([key, value]) => `${CQLBuilder.AT_MODIFIER_PREFIX}${key}=${value}`)
-      .join('');
+    const queued = this._consumePendingBooleanModifiers();
+    const modChain = this._serializeBooleanModifiers([...(modifiers ?? []), ...queued]);
 
-    const quotedValue = typeof searchValue === 'string' ? `"${this._getEscapedValue(searchValue, options)}"` : searchValue;
-
-    this.queryParts.push(`${field} =${modifiersChain} ${quotedValue}`);
-    this._applyModifiers();
-    this.requiresImplicitAnd = true;
-
-    return this;
-  }
-
-  /**
-   * OR-style array search across multiple fields
-   * @param {string} field - Array field name
-   * @param {string|string[]} modifiers - Modifier(s) to search
-   * @param {string|number} searchValue - Value to search for
-   * @param {Object} [options] - Optional parameters for the condition
-   * @param {boolean} [options.escapeCQL] - Whether to escape special CQL characters (`"` or `\`") in the value
-   * @returns {CQLBuilder}
-   */
-  orModifiersSearch(field, modifiers, searchValue, options = {}) {
-    if (this._shouldAddImplicitAnd()) {
-      this.queryParts.push(CQLBuilder.OPERATORS.AND);
-    }
-
-    const modifiersArray = Array.isArray(modifiers) ? modifiers : [modifiers];
-    const modifiersChain = modifiersArray.map(m => `${CQLBuilder.AT_MODIFIER_PREFIX}${m}`).join('');
-    const quotedValue = typeof searchValue === 'string' ? `"${this._getEscapedValue(searchValue, options)}"` : searchValue;
-
-    this.queryParts.push(`${field} =${modifiersChain} ${quotedValue}`);
-    this._applyModifiers();
-    this.requiresImplicitAnd = true;
+    this.queryParts.push(`${CQLBuilder.OPERATORS.PROX}${modChain}`);
+    this.requiresImplicitAnd = false;
 
     return this;
   }
@@ -330,13 +336,10 @@ export class CQLBuilder {
    */
   sortByMultiple(sorts) {
     const sortClauses = sorts.map(({ field, order }) => {
-      const normalizedOrder = order.startsWith('sort.')
-        ? order
-        : (() => (
-          order === CQLBuilder.SORT_ORDERS.ASC
-            ? CQLBuilder.SORT_ORDERS.SORT_ASCENDING
-            : CQLBuilder.SORT_ORDERS.SORT_DESCENDING
-        ))();
+      const defaultOrder = order === CQLBuilder.SORT_ORDERS.ASC
+        ? CQLBuilder.SORT_ORDERS.SORT_ASCENDING
+        : CQLBuilder.SORT_ORDERS.SORT_DESCENDING;
+      const normalizedOrder = order.startsWith('sort.') ? order : defaultOrder;
 
       return `${field}/${normalizedOrder}`;
     });
@@ -356,22 +359,75 @@ export class CQLBuilder {
     return this.sortByMultiple([{ field, order }]);
   }
 
-  // ===== MODIFIERS =====
+  // ===== RELATION MODIFIERS =====
+  /**
+   * Adds one or more relation modifiers to the next condition.
+   *
+   * Relation modifiers are appended directly to the relation operator,
+   * following standard CQL syntax:
+   *
+   * field =/@modifier "value"
+   * field =/@modifier=value "value"
+   *
+   * Modifiers are applied only to the next condition and are cleared
+   * automatically after use.
+   *
+   * @param {string} name - Modifier name (for example: '@locationId')
+   * @param {string|number|boolean} [value] - Optional modifier value
+   * @returns {CQLBuilder} Returns self for method chaining
+   */
+  relationModifier(name, value) {
+    this.currentRelationModifiers.push(value === undefined ? name : `${name}=${value}`);
+
+    return this;
+  }
 
   /**
-   * Adds a modifier to the next condition
-   * @param {string} name - Modifier name
-   * @param {string|number|boolean} value - Modifier value
-   * @returns {CQLBuilder}
+   * Queues multiple relation modifiers at once. Shorthand for chaining {@link relationModifier}.
+   * @param {Array<{name: string, value?: any}>} mods - Modifiers to queue.
+   *   Each entry produces `/@name` (no value) or `/@name=value`.
+   * @returns {CQLBuilder} Returns self for method chaining
    */
-  modifier(name, value) {
-    this.currentModifiers[name] = value;
+  relationModifiers(mods) {
+    mods.forEach(({ name, value }) => this.relationModifier(name, value));
+
+    return this;
+  }
+
+  /**
+   * Queues a single boolean modifier for the next boolean operator (and/or/not/prox).
+   * Modifiers are consumed and cleared when the operator method is called.
+   * @param {string} name - Modifier name (e.g. 'unit', 'distance', 'unordered')
+   * @param {*} [value] - Optional modifier value. Omit for flag-style modifiers (e.g. 'unordered').
+   * @param {string} [symbol='='] - Comparison symbol between name and value (e.g. '<=' for distance<=1).
+   * @returns {CQLBuilder} Returns self for method chaining
+   */
+  booleanModifier(name, value, symbol) {
+    this.currentBooleanModifiers.push(
+      value === undefined ? { name } : { name, value, ...(symbol ? { symbol } : {}) },
+    );
+
+    return this;
+  }
+
+  /**
+   * Queues multiple boolean modifiers at once. Shorthand for chaining {@link booleanModifier}.
+   * @param {Array<{name: string, value?: any, symbol?: string}>} mods - Modifiers to queue.
+   * @returns {CQLBuilder} Returns self for method chaining
+   */
+  booleanModifiers(mods) {
+    this.currentBooleanModifiers.push(...mods);
 
     return this;
   }
 
   // ===== GROUPING =====
 
+  /**
+   * Wraps a sub-query in parentheses.
+   * @param {function(CQLBuilder): void} callback - Receives a fresh builder; its result becomes the grouped sub-query.
+   * @returns {CQLBuilder} Returns self for method chaining
+   */
   group(callback) {
     if (this._shouldAddImplicitAnd()) {
       this.queryParts.push(CQLBuilder.OPERATORS.AND);
@@ -382,8 +438,7 @@ export class CQLBuilder {
     const groupBuilder = new CQLBuilder();
 
     callback(groupBuilder);
-    this.queryParts.push(groupBuilder.build());
-    this.queryParts.push(CQLBuilder.GROUP_TOKENS.CLOSE);
+    this.queryParts.push(groupBuilder.build(), CQLBuilder.GROUP_TOKENS.CLOSE);
     this.requiresImplicitAnd = true;
 
     return this;
@@ -416,6 +471,10 @@ export class CQLBuilder {
    * @param {string} field - The field name to query against
    * @param {string} operator - The comparison operator (=, ==, >, etc.)
    * @param {string|number} value - The value to compare against
+   * @param {Object} [options] - Optional parameters
+   * @param {boolean} [options.escapeCQL] - Whether to escape special CQL characters in the value
+   * @param {function} [options.formatter] - Custom value formatter
+   * @param {Array<{name: string, value?: any}>} [options.modifiers] - Inline relation modifiers
    * @returns {CQLBuilder} Returns self for method chaining
    */
   _addCondition(field, operator, value, options = {}) {
@@ -423,29 +482,47 @@ export class CQLBuilder {
       this.queryParts.push(CQLBuilder.OPERATORS.AND);
     }
 
-    const quotedValue = typeof value === 'string' ? `"${this._getEscapedValue(value, options)}"` : value;
+    const { modifiers: inlineModifiers, ...valueOptions } = options;
 
-    this.queryParts.push(`${field} ${operator} ${quotedValue}`);
-    this._applyModifiers();
+    if (inlineModifiers) {
+      this.currentRelationModifiers.unshift(
+        ...inlineModifiers.map(m => (m.value === undefined ? m.name : `${m.name}=${m.value}`)),
+      );
+    }
+
+    const formattedValue = this._formatValue(value, valueOptions);
+    const relationModifiersChain = this._buildRelationModifiers();
+
+    this.queryParts.push(`${field} ${operator}${relationModifiersChain} ${formattedValue}`);
     this.requiresImplicitAnd = true;
 
     return this;
   }
 
   /**
-   * Applies current modifiers to the last condition
+   * Builds and clears the currently queued relation modifiers.
+   *
+   * Converts queued modifiers into CQL relation modifier syntax:
+   *
+   * ['@locationId'] -> '/@locationId'
+   *
+   * ['@type=Rush', '@status=Open'] -> '/@type=Rush/@status=Open'
+   *
    * @private
+   * @returns {string} Formatted relation modifier string or empty string
    */
-  _applyModifiers() {
-    if (Object.keys(this.currentModifiers).length > 0) {
-      const lastIndex = this.queryParts.length - 1;
-      const modifiers = Object.entries(this.currentModifiers)
-        .map(([k, v]) => `${k}=${v}`)
-        .join(' ');
-
-      this.queryParts[lastIndex] += ` ${modifiers}`;
-      this.currentModifiers = {};
+  _buildRelationModifiers() {
+    if (this.currentRelationModifiers.length === 0) {
+      return '';
     }
+
+    const result = this.currentRelationModifiers
+      .map(modifier => `/${modifier}`)
+      .join('');
+
+    this.currentRelationModifiers = [];
+
+    return result;
   }
 
   /**
@@ -459,16 +536,21 @@ export class CQLBuilder {
       !this._lastPartIsOperator();
   }
 
+  /**
+   * Returns true when the last queued part is a boolean operator token.
+   * Used to guard against duplicate operator calls and incorrect implicit-AND insertion.
+   * @private
+   * @returns {boolean}
+   */
   _lastPartIsOperator() {
     if (this.queryParts.length === 0) return false;
-    const last = this.queryParts[this.queryParts.length - 1];
+    const last = this.queryParts.at(-1);
 
-    return [
-      CQLBuilder.OPERATORS.AND,
-      CQLBuilder.OPERATORS.OR,
-      CQLBuilder.OPERATORS.NOT,
-      CQLBuilder.GROUP_TOKENS.OPEN,
-    ].includes(last);
+    return last === CQLBuilder.GROUP_TOKENS.OPEN
+      || last.startsWith(CQLBuilder.OPERATORS.AND)
+      || last.startsWith(CQLBuilder.OPERATORS.OR)
+      || last.startsWith(CQLBuilder.OPERATORS.NOT)
+      || last.startsWith(CQLBuilder.OPERATORS.PROX);
   }
 
   /**
@@ -477,14 +559,61 @@ export class CQLBuilder {
    */
   _reset() {
     this.queryParts = [];
-    this.currentModifiers = {};
     this.requiresImplicitAnd = false;
     this.scopedIndex = null;
+    this.currentBooleanModifiers = [];
+  }
+
+  /**
+   * Returns queued boolean modifiers and clears the queue.
+   * @private
+   * @returns {Array<{name: string, value?: any, symbol?: string}>}
+   */
+  _consumePendingBooleanModifiers() {
+    const mods = this.currentBooleanModifiers;
+
+    this.currentBooleanModifiers = [];
+
+    return mods;
+  }
+
+  /**
+   * Serializes an array of boolean modifier objects into a CQL modifier chain string.
+   * @private
+   * @param {Array<{name: string, value?: any, symbol?: string}>} mods
+   * @returns {string} E.g. '/unit=word/distance<=1/unordered' or '' for an empty array
+   */
+  _serializeBooleanModifiers(mods) {
+    if (!mods.length) return '';
+
+    return mods.map(m => (
+      m.value === undefined ? `/${m.name}` : `/${m.name}${m.symbol ?? '='}${m.value}`
+    )).join('');
+  }
+
+  /**
+   * Formats a value for CQL output, applying any necessary escaping or custom formatting
+   * see {@link CQLBuilderValue} for details on value formatting and escaping
+   *
+   * @private
+   * @param {string|number} value - The value to format
+   * @param {Object} [options] - Optional parameters for value formatting
+   * @param {function} [options.formatter] - Custom formatter function to apply to the value
+   * @param {boolean} [options.escapeCQL] - Whether to escape special CQL characters (`"` or `\`") in the value (default: true)
+   * @returns {string|number} The formatted value, ready for inclusion in the CQL query
+   */
+  _formatValue(value, options = {}) {
+    if (typeof options.formatter === 'function') {
+      return options.formatter(value);
+    }
+
+    return typeof value === 'string' ? `"${this._getEscapedValue(value, options)}"` : value;
   }
 
   /**
    * Escape special characters for CQL
    * @private
+   * @param {string} value - The value to escape
    * @param {Object} [options] - Optional parameters for the condition
    * @param {boolean} [options.escapeCQL] - Whether to escape special CQL characters (`"` or `\`") in the value
    * @returns {string} Either an escaped string or initial value when `escapeCQL` option is `false`

--- a/lib/utils/CQLBuilder/CQLBuilder.test.js
+++ b/lib/utils/CQLBuilder/CQLBuilder.test.js
@@ -61,52 +61,6 @@ describe('CQLBuilder', () => {
     });
   });
 
-  describe('Array Search Modifiers', () => {
-    it('AND modifiers with single modifier', () => {
-      const query = builder
-        .andModifiersSearch('contributors', { type: 'author' }, 'John')
-        .build();
-
-      expect(query).toBe('contributors =/@type=author "John"');
-    });
-
-    it('AND modifiers with multiple modifiers', () => {
-      const query = builder
-        .andModifiersSearch(
-          'contributors',
-          { type: 'author', role: 'primary' },
-          'John',
-        )
-        .build();
-
-      expect(query).toBe('contributors =/@type=author/@role=primary "John"');
-    });
-
-    it('OR modifiers with single modifier', () => {
-      const query = builder
-        .orModifiersSearch('contributors', 'type', 'John')
-        .build();
-
-      expect(query).toBe('contributors =/@type "John"');
-    });
-
-    it('OR modifiers with multiple modifiers', () => {
-      const query = builder
-        .orModifiersSearch('contributors', ['type', 'role'], 'John')
-        .build();
-
-      expect(query).toBe('contributors =/@type/@role "John"');
-    });
-
-    it('modifiers with numeric values', () => {
-      const query = builder
-        .andModifiersSearch('items', { locationId: 123 }, 'book')
-        .build();
-
-      expect(query).toBe('items =/@locationId=123 "book"');
-    });
-  });
-
   describe('Sorting', () => {
     it('single field sort', () => {
       const query = builder
@@ -165,9 +119,9 @@ describe('CQLBuilder', () => {
 
     it('combined AND/OR modifiers with sorting', () => {
       const query = builder
-        .andModifiersSearch('metadata', { type: 'book' }, 'dinosaur')
+        .fuzzy('metadata', 'dinosaur', { modifiers: [{ name: '@type', value: 'book' }] })
         .or()
-        .orModifiersSearch('classification', ['category', 'genre'], 'science')
+        .fuzzy('classification', 'science', { modifiers: [{ name: '@category' }, { name: '@genre' }] })
         .sortByMultiple([
           { field: 'published', order: 'desc' },
           { field: 'title', order: 'asc' },
@@ -181,21 +135,20 @@ describe('CQLBuilder', () => {
       );
     });
 
-    it('grouped conditions with modifiers', () => {
+    it('grouped conditions', () => {
       const query = builder
         .equal('status', 'active')
         .group((b) => b
-          .andModifiersSearch('authors', { type: 'primary' }, 'John')
+          .fuzzy('authors', 'John', { modifiers: [{ name: '@type', value: 'primary' }] })
           .or()
-          .orModifiersSearch('authors', ['secondary', 'editor'], 'Jane'))
-        .modifier('caseInsensitive', true)
+          .fuzzy('authors', 'Jane', { modifiers: [{ name: '@secondary' }, { name: '@editor' }] }))
         .fuzzy('title', 'history')
         .build();
 
       expect(query).toBe(
         'status=="active" AND ' +
         '(authors =/@type=primary "John" OR authors =/@secondary/@editor "Jane") AND ' +
-        'title="history" caseInsensitive=true',
+        'title="history"',
       );
     });
 
@@ -234,18 +187,6 @@ describe('CQLBuilder', () => {
       builder.equal('title', '1984').build();
       expect(builder.build()).toBe('');
     });
-
-    it('modifiers apply only to next condition', () => {
-      const query = builder
-        .modifier('caseInsensitive', true)
-        .equal('field1', 'value1')
-        .equal('field2', 'value2')
-        .build();
-
-      expect(query).toBe(
-        'field1=="value1" caseInsensitive=true AND field2=="value2"',
-      );
-    });
   });
 
   describe('OR Combinations', () => {
@@ -271,9 +212,9 @@ describe('CQLBuilder', () => {
 
     it('should handle OR between AND-modifiers conditions', () => {
       const query = builder
-        .andModifiersSearch('items', { type: 'book' }, 'history')
+        .fuzzy('items', 'history', { modifiers: [{ name: '@type', value: 'book' }] })
         .or()
-        .andModifiersSearch('items', { type: 'journal' }, 'science')
+        .fuzzy('items', 'science', { modifiers: [{ name: '@type', value: 'journal' }] })
         .build();
 
       expect(query).toBe(
@@ -285,7 +226,7 @@ describe('CQLBuilder', () => {
       const query = builder
         .equal('category', 'fiction')
         .or()
-        .andModifiersSearch('metadata', { lang: 'en' }, 'dinosaur')
+        .fuzzy('metadata', 'dinosaur', { modifiers: [{ name: '@lang', value: 'en' }] })
         .or()
         .contains('tags', 'popular')
         .build();
@@ -337,9 +278,9 @@ describe('CQLBuilder', () => {
 
     it('should handle OR with mixed modifiers', () => {
       const query = builder
-        .andModifiersSearch('contributors', { role: 'author' }, 'John')
+        .fuzzy('contributors', 'John', { modifiers: [{ name: '@role', value: 'author' }] })
         .or()
-        .orModifiersSearch('contributors', ['editor', 'reviewer'], 'Jane')
+        .fuzzy('contributors', 'Jane', { modifiers: [{ name: '@editor' }, { name: '@reviewer' }] })
         .build();
 
       expect(query).toBe(
@@ -351,7 +292,7 @@ describe('CQLBuilder', () => {
       const query = builder
         .equal('lang', 'en')
         .or()
-        .andModifiersSearch('metadata', { lang: 'fr' }, 'special')
+        .fuzzy('metadata', 'special', { modifiers: [{ name: '@lang', value: 'fr' }] })
         .or()
         .contains('notes', 'multilingual')
         .sortBy('created', 'desc')
@@ -388,13 +329,191 @@ describe('CQLBuilder', () => {
     });
   });
 
+  describe('Modifiers', () => {
+    describe('Boolean modifiers', () => {
+      it('booleanModifier() before and() appends modifier to operator', () => {
+        const query = builder
+          .fuzzy('title', 'fish')
+          .booleanModifier('rel.algorithm', 'fuzzy')
+          .and()
+          .fuzzy('author', 'Smith')
+          .build();
+
+        expect(query).toBe('title="fish" AND/rel.algorithm=fuzzy author="Smith"');
+      });
+
+      it('booleanModifier() with custom symbol', () => {
+        const query = builder
+          .fuzzy('title', 'fish')
+          .booleanModifier('distance', 1, '<=')
+          .prox()
+          .fuzzy('title', 'chips')
+          .build();
+
+        expect(query).toBe('title="fish" prox/distance<=1 title="chips"');
+      });
+
+      it('booleanModifier() before or()', () => {
+        const query = builder
+          .equal('status', 'active')
+          .booleanModifier('unit', 'sentence')
+          .or()
+          .equal('status', 'pending')
+          .build();
+
+        expect(query).toBe('status=="active" OR/unit=sentence status=="pending"');
+      });
+
+      it('booleanModifier() before not()', () => {
+        const query = builder
+          .allRecords()
+          .booleanModifier('unit', 'word')
+          .not()
+          .equal('deleted', true)
+          .build();
+
+        expect(query).toBe('cql.allRecords=1 NOT/unit=word deleted==true');
+      });
+
+      it('booleanModifiers() queues multiple modifiers', () => {
+        const query = builder
+          .fuzzy('title', 'fish')
+          .booleanModifiers([
+            { name: 'unit', value: 'word' },
+            { name: 'distance', value: 1, symbol: '<=' },
+            { name: 'unordered' },
+          ])
+          .prox()
+          .fuzzy('title', 'chips')
+          .build();
+
+        expect(query).toBe('title="fish" prox/unit=word/distance<=1/unordered title="chips"');
+      });
+    });
+
+    describe('prox()', () => {
+      it('prox() with no args produces bare prox', () => {
+        const query = builder
+          .fuzzy('title', 'fish')
+          .prox()
+          .fuzzy('title', 'chips')
+          .build();
+
+        expect(query).toBe('title="fish" prox title="chips"');
+      });
+
+      it('prox() with inline modifiers', () => {
+        const query = builder
+          .fuzzy('title', 'fish')
+          .prox([
+            { name: 'unit', value: 'word' },
+            { name: 'distance', value: 3, symbol: '<=' },
+          ])
+          .fuzzy('title', 'chips')
+          .build();
+
+        expect(query).toBe('title="fish" prox/unit=word/distance<=3 title="chips"');
+      });
+
+      it('prox() is a no-op when called with no left-hand term', () => {
+        const query = builder
+          .prox()
+          .fuzzy('title', 'fish')
+          .build();
+
+        expect(query).toBe('title="fish"');
+      });
+
+      it('duplicate prox() calls are ignored', () => {
+        const query = builder
+          .fuzzy('title', 'fish')
+          .prox()
+          .prox()
+          .fuzzy('title', 'chips')
+          .build();
+
+        expect(query).toBe('title="fish" prox title="chips"');
+      });
+    });
+
+    describe('Relation modifiers', () => {
+      it('relationModifier() still works as before', () => {
+        const query = builder
+          .relationModifier('@type', 'author')
+          .fuzzy('contributors', 'John')
+          .build();
+
+        expect(query).toBe('contributors =/@type=author "John"');
+      });
+
+      it('relationModifiers() plural shorthand produces same output as chained calls', () => {
+        const chained = new CQLBuilder()
+          .relationModifier('@type', 'author')
+          .relationModifier('@role', 'primary')
+          .fuzzy('contributors', 'John')
+          .build();
+
+        const plural = builder
+          .relationModifiers([{ name: '@type', value: 'author' }, { name: '@role', value: 'primary' }])
+          .fuzzy('contributors', 'John')
+          .build();
+
+        expect(plural).toBe(chained);
+        expect(plural).toBe('contributors =/@type=author/@role=primary "John"');
+      });
+
+      it('inline modifiers on fuzzy() via options.modifiers', () => {
+        const query = builder
+          .fuzzy('contributors', 'John', { modifiers: [{ name: '@type', value: 'author' }] })
+          .build();
+
+        expect(query).toBe('contributors =/@type=author "John"');
+      });
+
+      it('inline modifiers without value (OR-style)', () => {
+        const query = builder
+          .fuzzy('contributors', 'John', { modifiers: [{ name: '@type' }, { name: '@role' }] })
+          .build();
+
+        expect(query).toBe('contributors =/@type/@role "John"');
+      });
+
+      it('inline modifiers on equal()', () => {
+        const query = builder
+          .equal('items', 'book', { modifiers: [{ name: '@locationId', value: 123 }] })
+          .build();
+
+        expect(query).toBe('items ==/@locationId=123 "book"');
+      });
+
+      it('inline modifiers on relation() in three-call API', () => {
+        const query = builder
+          .index('contributors')
+          .relation('=', [{ name: '@type', value: 'author' }])
+          .value('John')
+          .build();
+
+        expect(query).toBe('contributors =/@type=author "John"');
+      });
+
+      it('inline modifiers merge with queued relationModifier()', () => {
+        const query = builder
+          .relationModifier('@role', 'primary')
+          .fuzzy('contributors', 'John', { modifiers: [{ name: '@type', value: 'author' }] })
+          .build();
+
+        expect(query).toBe('contributors =/@type=author/@role=primary "John"');
+      });
+    });
+  });
+
   describe('Options application', () => {
     describe('escapeCQL', () => {
       it.each([
         [true, '"quoted"', String.raw`\"quoted\"`],
         [false, '"quoted"', String.raw`"quoted"`],
-        [true, '"Value \\ with escaping', String.raw`\"Value \\ with escaping`],
-        [false, '"Value \\ without escaping', String.raw`"Value \ without escaping`],
+        [true, String.raw`"Value \ with escaping`, String.raw`\"Value \\ with escaping`],
+        [false, String.raw`"Value \ without escaping`, String.raw`"Value \ without escaping`],
       ])('should properly escape search value when "escapeCQL" option value is "%s"', (escapeCQL, rawValue, expected) => {
         const fieldName = 'filter';
 
@@ -411,8 +530,8 @@ describe('CQLBuilder', () => {
 
         expect(builder.equal(fieldName, rawValue, { escapeCQL }).build()).toBe(`${fieldName}=="${expected}"`);
         expect(builder.fuzzy(fieldName, rawValue, { escapeCQL }).build()).toBe(`${fieldName}="${expected}"`);
-        expect(builder.andModifiersSearch(fieldName, { foo: 'bar' }, rawValue, { escapeCQL }).build()).toBe(`${fieldName} =/@foo=bar "${expected}"`);
-        expect(builder.orModifiersSearch(fieldName, ['foo'], rawValue, { escapeCQL }).build()).toBe(`${fieldName} =/@foo "${expected}"`);
+        expect(builder.fuzzy(fieldName, rawValue, { escapeCQL, modifiers: [{ name: '@foo', value: 'bar' }] }).build()).toBe(`${fieldName} =/@foo=bar "${expected}"`);
+        expect(builder.fuzzy(fieldName, rawValue, { escapeCQL, modifiers: [{ name: '@foo' }] }).build()).toBe(`${fieldName} =/@foo "${expected}"`);
 
         expect(
           builder

--- a/lib/utils/CQLBuilder/CQLBuilder.test.js
+++ b/lib/utils/CQLBuilder/CQLBuilder.test.js
@@ -1,3 +1,5 @@
+import { escapeCqlWildcards } from '@folio/stripes/util';
+
 import { CQLBuilder } from './CQLBuilder';
 
 describe('CQLBuilder', () => {
@@ -509,12 +511,15 @@ describe('CQLBuilder', () => {
 
   describe('Options application', () => {
     describe('escapeCQL', () => {
+      const customEscapeFn = (s) => escapeCqlWildcards(s);
+
       it.each([
         [true, '"quoted"', String.raw`\"quoted\"`],
         [false, '"quoted"', String.raw`"quoted"`],
         [true, String.raw`"Value \ with escaping`, String.raw`\"Value \\ with escaping`],
         [false, String.raw`"Value \ without escaping`, String.raw`"Value \ without escaping`],
-      ])('should properly escape search value when "escapeCQL" option value is "%s"', (escapeCQL, rawValue, expected) => {
+        [customEscapeFn, String.raw`"[Value] \ *^ with "custom" escaping`, String.raw`\"[Value] \\ \*\^ with \"custom\" escaping`],
+      ])('should properly escape search value when "escapeCQL" option value is %s"', (escapeCQL, rawValue, expected) => {
         const fieldName = 'filter';
 
         const methods = new Map([
@@ -546,6 +551,25 @@ describe('CQLBuilder', () => {
 
           expect(query).toBe(`${fieldName} ${operator} "${expected}"`);
         });
+      });
+    });
+
+    describe('formatter', () => {
+      it('should use custom formatter when provided', () => {
+        const customFormatter = (value) => `custom:${value}`;
+        const query = builder.equal('field', 'value', { formatter: customFormatter }).build();
+
+        expect(query).toBe('field==custom:value');
+      });
+    });
+
+    describe('native array value', () => {
+      it('should format a native array the same as CQLBuilderArrayValue', () => {
+        expect(builder.fuzzy('field', ['a', 'b']).build()).toBe('field=("a" OR "b")');
+      });
+
+      it('should unwrap a single-element array', () => {
+        expect(builder.fuzzy('field', ['only']).build()).toBe('field="only"');
       });
     });
   });

--- a/lib/utils/CQLBuilder/CQLBuilderValue.js
+++ b/lib/utils/CQLBuilder/CQLBuilderValue.js
@@ -1,0 +1,14 @@
+/**
+ * An abstract class representing a value in CQL Builder.
+ * Any value that needs to be formatted in a specific way for CQL queries should extend this class and implement the toCQL method.
+ * This allows for consistent handling of complex values across the CQL Builder.
+*/
+export class CQLBuilderValue {
+  toCQL() {
+    throw new Error('toCQL method must be implemented by subclasses of CQLBuilderValue');
+  }
+
+  toString() {
+    return this.toCQL();
+  }
+}

--- a/lib/utils/CQLBuilder/CQLBuilderValue.js
+++ b/lib/utils/CQLBuilder/CQLBuilderValue.js
@@ -1,14 +1,45 @@
+import { identity } from 'lodash';
+
+import { escapeCqlValue } from '@folio/stripes/util';
+
 /**
  * An abstract class representing a value in CQL Builder.
  * Any value that needs to be formatted in a specific way for CQL queries should extend this class and implement the toCQL method.
  * This allows for consistent handling of complex values across the CQL Builder.
 */
 export class CQLBuilderValue {
+  constructor(input, options = {}) {
+    this.input = input;
+    this.escapeCQL = options.escapeCQL ?? true;
+  }
+
   toCQL() {
     throw new Error('toCQL method must be implemented by subclasses of CQLBuilderValue');
   }
 
   toString() {
     return this.toCQL();
+  }
+
+  /**
+   * Escape special characters for CQL
+   * @private
+   * @param {string} value - The value to escape
+   * @param {Object} [options] - Optional parameters for the condition
+   * @param {boolean|function} [options.escapeCQL] - Whether to escape special CQL characters (`"` or `\`") in the value or a custom escape function
+   * @returns {string} Either an escaped string or initial value when `escapeCQL` option is `false`
+   */
+  _getEscapedValue(value, options = {}) {
+    const { escapeCQL = true } = options;
+
+    // If a custom escape function is provided, use it
+    if (typeof escapeCQL === 'function') {
+      return escapeCQL(value);
+    }
+
+    // If escapeCQL is true, use the default escape function; otherwise, return the value as-is
+    const escapeFn = escapeCQL ? escapeCqlValue : identity;
+
+    return escapeFn(value);
   }
 }

--- a/lib/utils/CQLBuilder/README.md
+++ b/lib/utils/CQLBuilder/README.md
@@ -56,25 +56,55 @@ const query = new CQLBuilder()
 // (location=="main" AND (format=="print" OR format=="large-print"))
 ```
 
-### Modifiers Usage
+### Relation Modifiers
 
-**AND-style modifiers search:**
+**AND-style (object — each key/value becomes `/@key=value`):**
 ```javascript
 const query = new CQLBuilder()
-  .andModifiersSearch('items', {
-    location: 'main',
-    status: 'available'
-  }, 'science')
+  .fuzzy('items', 'science', { modifiers: [
+    { name: '@location', value: 'main' },
+    { name: '@status', value: 'available' },
+  ]})
   .build();
 // items =/@location=main/@status=available "science"
 ```
 
-**OR-style modifiers:**
+**OR-style (name-only modifiers):**
 ```javascript
 const query = new CQLBuilder()
-  .orModifiersSearch('contributors', ['author', 'editor'], 'Tolkien')
+  .fuzzy('contributors', 'Tolkien', { modifiers: [
+    { name: '@author' },
+    { name: '@editor' },
+  ]})
   .build();
 // contributors =/@author/@editor "Tolkien"
+```
+
+### Boolean Modifiers and Proximity
+
+**Boolean modifiers before `and()`/`or()`:**
+```javascript
+const query = new CQLBuilder()
+  .fuzzy('text', 'quantum')
+  .booleanModifier('unit', 'word')
+  .and()
+  .fuzzy('text', 'physics')
+  .build();
+// text="quantum" AND/unit=word text="physics"
+```
+
+**Proximity search:**
+```javascript
+const query = new CQLBuilder()
+  .fuzzy('text', 'quantum')
+  .prox([
+    { name: 'unit', value: 'word' },
+    { name: 'distance', value: 1, symbol: '<=' },
+    { name: 'unordered' },
+  ])
+  .fuzzy('text', 'physics')
+  .build();
+// text="quantum" prox/unit=word/distance<=1/unordered text="physics"
 ```
 
 ### Sorting
@@ -113,14 +143,6 @@ const query = new CQLBuilder()
   .build();
 ```
 
-**Proximity search:**
-```javascript
-const query = new CQLBuilder()
-  .prox(3, 'sentence')
-  .equal('text', 'quantum physics')
-  .build();
-// prox/sentence/3 text=="quantum physics"
-```
 
 ## .and() Method Behavior
 
@@ -151,12 +173,16 @@ const q2 = new CQLBuilder()
 
 | Method | Description | Example |
 |--------|-------------|---------|
-| `.equal(field, value)` | Exact match | `title=="Book"` |
-| `.fuzzy(field, value)` | Fuzzy match | `title="Book*"` |
-| `.contains(field, value)` | Contains all terms | `subject all "science physics"` |
+| `.equal(field, value, opts?)` | Exact match | `title=="Book"` |
+| `.fuzzy(field, value, opts?)` | Fuzzy match | `title="Book*"` |
+| `.contains(field, value, opts?)` | Contains all terms | `subject all "science physics"` |
 | `.group(callback)` | Logical grouping | `(a==1 OR b==2)` |
-| `.andModifiersSearch()` | AND-style array search | `items =/@type=book/@loc=main "science"` |
-| `.sortByMultiple()` | Multi-field sorting | `sortBy year/desc title/asc` |
+| `.booleanModifier(name, value?, symbol?)` | Queue modifier for next boolean op | `.booleanModifier('unit', 'word').and()` |
+| `.booleanModifiers(mods[])` | Queue multiple boolean modifiers | — |
+| `.relationModifier(name, value?)` | Queue relation modifier for next clause | `=/@type=book` |
+| `.relationModifiers(mods[])` | Queue multiple relation modifiers | — |
+| `.prox(mods[]?)` | Proximity operator | `term1 prox/unit=word term2` |
+| `.sortByMultiple(specs[])` | Multi-field sorting | `sortBy year/sort.descending title/sort.ascending` |
 
 ## Best Practices
 

--- a/lib/utils/CQLBuilder/index.js
+++ b/lib/utils/CQLBuilder/index.js
@@ -1,1 +1,2 @@
 export { CQLBuilder } from './CQLBuilder';
+export * from './value-formatters';

--- a/lib/utils/CQLBuilder/value-formatters/CQLBuilderArrayValue.js
+++ b/lib/utils/CQLBuilder/value-formatters/CQLBuilderArrayValue.js
@@ -3,22 +3,17 @@ import { CQLBuilder } from '../CQLBuilder';
 import { CQLBuilderValue } from '../CQLBuilderValue';
 
 export class CQLBuilderArrayValue extends CQLBuilderValue {
-  constructor(values) {
-    super();
-    this.values = values;
+  constructor(input, options = {}) {
+    super(input, options);
   }
 
   toCQL() {
-    const formattedValue = this.values.map(this._formatValue.bind(this)).join(` ${CQLBuilder.OPERATORS.OR} `);
+    const formattedValue = this.input.map(this._formatValue.bind(this)).join(` ${CQLBuilder.OPERATORS.OR} `);
 
-    return `(${formattedValue})`;
-  }
-
-  toString() {
-    return this.toCQL();
+    return this.input.length > 1 ? `(${formattedValue})` : formattedValue;
   }
 
   _formatValue(value) {
-    return quote(value);
+    return quote(this._getEscapedValue(value, { escapeCQL: this.escapeCQL }));
   }
 }

--- a/lib/utils/CQLBuilder/value-formatters/CQLBuilderArrayValue.js
+++ b/lib/utils/CQLBuilder/value-formatters/CQLBuilderArrayValue.js
@@ -1,0 +1,20 @@
+import { quote } from '../../quote';
+import { CQLBuilder } from '../CQLBuilder';
+import { CQLBuilderValue } from '../CQLBuilderValue';
+
+export class CQLBuilderArrayValue extends CQLBuilderValue {
+  constructor(values) {
+    super();
+    this.values = values;
+  }
+
+  toCQL() {
+    const formattedValue = this.values.map(this._formatValue.bind(this)).join(` ${CQLBuilder.OPERATORS.OR} `);
+
+    return `(${formattedValue})`;
+  }
+
+  _formatValue(value) {
+    return quote(value);
+  }
+}

--- a/lib/utils/CQLBuilder/value-formatters/CQLBuilderArrayValue.js
+++ b/lib/utils/CQLBuilder/value-formatters/CQLBuilderArrayValue.js
@@ -14,6 +14,10 @@ export class CQLBuilderArrayValue extends CQLBuilderValue {
     return `(${formattedValue})`;
   }
 
+  toString() {
+    return this.toCQL();
+  }
+
   _formatValue(value) {
     return quote(value);
   }

--- a/lib/utils/CQLBuilder/value-formatters/CQLBuilderStringValue.js
+++ b/lib/utils/CQLBuilder/value-formatters/CQLBuilderStringValue.js
@@ -1,0 +1,16 @@
+import { quote } from '../../quote';
+import { CQLBuilderValue } from '../CQLBuilderValue';
+
+export class CQLBuilderStringValue extends CQLBuilderValue {
+  constructor(input, options = {}) {
+    super(input, options);
+  }
+
+  toCQL() {
+    return this._formatValue(this.input);
+  }
+
+  _formatValue(value) {
+    return quote(this._getEscapedValue(value, { escapeCQL: this.escapeCQL }));
+  }
+}

--- a/lib/utils/CQLBuilder/value-formatters/index.js
+++ b/lib/utils/CQLBuilder/value-formatters/index.js
@@ -1,0 +1,1 @@
+export { CQLBuilderArrayValue } from './CQLBuilderArrayValue';

--- a/lib/utils/CQLBuilder/value-formatters/index.js
+++ b/lib/utils/CQLBuilder/value-formatters/index.js
@@ -1,1 +1,2 @@
 export { CQLBuilderArrayValue } from './CQLBuilderArrayValue';
+export { CQLBuilderStringValue } from './CQLBuilderStringValue';

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -35,6 +35,7 @@ export * from './handleKeyCommand';
 export * from './hooks';
 export * from './invoiceExport';
 export * from './parseNumberFieldValue';
+export * from './quote';
 export * from './searchAndSort';
 export * from './validateRequired';
 export * from './validateURL';

--- a/lib/utils/quote.js
+++ b/lib/utils/quote.js
@@ -1,0 +1,5 @@
+export const quote = (value, options = {}) => {
+  const { quotes = '"' } = options;
+
+  return `${quotes}${value}${quotes}`;
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-acq-components",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "description": "Component library for Stripes Acquisitions modules",
   "publishConfig": {
     "registry": "https://repository.folio.org/repository/npm-folio/"


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://folio-org.atlassian.net/browse/UISACQCOMP-300

- Update order storage related queries to use `==` (equal) instead of `=` (fuzze);
- Update `CQLBuilder` to support relation modifiers + clean the public API;
- Add `buildMultiOptionCqlQuery` function helper to build CQL queries for value or array of values. (Support relation modifiers).
