### PR TITLE
Support deprecated acquisition methods in useAcqMethodsOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [7.2.0](IN PROGRESS)
 
 * Update CQL Builder to support new indices. Refs UISACQCOMP-300.
+* Support deprecated acquisition methods in `useAcqMethodsOptions` and add `getAcqMethodLabel`. Refs UISACQCOMP-301.
 
 ## [7.1.0](https://github.com/folio-org/stripes-acq-components/tree/v7.1.0) (2026-04-15)
 [Full Changelog](https://github.com/folio-org/stripes-acq-components/compare/v7.0.5...v7.1.0)

--- a/lib/hooks/useAcqMethodsOptions/index.js
+++ b/lib/hooks/useAcqMethodsOptions/index.js
@@ -1,1 +1,1 @@
-export { useAcqMethodsOptions } from './useAcqMethodsOptions';
+export { getAcqMethodLabel, useAcqMethodsOptions } from './useAcqMethodsOptions';

--- a/lib/hooks/useAcqMethodsOptions/useAcqMethodsOptions.js
+++ b/lib/hooks/useAcqMethodsOptions/useAcqMethodsOptions.js
@@ -5,20 +5,37 @@ import { ACQUISITION_METHOD } from '../../constants/order';
 
 const acqMethodMap = invert(ACQUISITION_METHOD);
 
-export const useAcqMethodsOptions = (records = []) => {
-  const { formatMessage } = useIntl();
+export const getAcqMethodLabel = (record, { intl, withDeprecatedSuffix = false } = {}) => {
+  const { value, deprecated } = record;
+  const translationKey = acqMethodMap[value];
+  const baseLabel = translationKey
+    ? intl.formatMessage({
+      id: `stripes-acq-components.acquisition_method.${translationKey}`,
+      defaultMessage: value,
+    })
+    : value;
 
-  return (
-    records.map(({ id, value }) => ({
-      label: acqMethodMap[value]
-        ? (
-          formatMessage({
-            id: `stripes-acq-components.acquisition_method.${acqMethodMap[value]}`,
-            defaultMessage: value,
-          })
-        )
-        : value,
-      value: id,
-    }))
-  );
+  if (withDeprecatedSuffix && deprecated) {
+    return intl.formatMessage(
+      { id: 'stripes-acq-components.acquisition_method.deprecatedSuffix', defaultMessage: '{name} (deprecated)' },
+      { name: baseLabel },
+    );
+  }
+
+  return baseLabel;
+};
+
+export const useAcqMethodsOptions = (records = [], {
+  excludeDeprecated = false,
+  selectedValue,
+  withDeprecatedSuffix = false,
+} = {}) => {
+  const intl = useIntl();
+
+  return records
+    .filter(({ id, deprecated }) => !excludeDeprecated || !deprecated || id === selectedValue)
+    .map((record) => ({
+      label: getAcqMethodLabel(record, { intl, withDeprecatedSuffix }),
+      value: record.id,
+    }));
 };

--- a/lib/hooks/useAcqMethodsOptions/useAcqMethodsOptions.test.js
+++ b/lib/hooks/useAcqMethodsOptions/useAcqMethodsOptions.test.js
@@ -1,10 +1,14 @@
 import { renderHook } from '@folio/jest-config-stripes/testing-library/react';
 
-import { useAcqMethodsOptions } from './useAcqMethodsOptions';
+import {
+  getAcqMethodLabel,
+  useAcqMethodsOptions,
+} from './useAcqMethodsOptions';
 
 const records = [
   { id: '001', value: 'Test method' },
   { id: '002', value: 'Purchase' },
+  { id: '003', value: 'Deprecated method', deprecated: true },
 ];
 
 describe('useAcqMethodsOptions', () => {
@@ -14,6 +18,7 @@ describe('useAcqMethodsOptions', () => {
     expect(result.current).toEqual([
       { label: records[0].value, value: records[0].id },
       { label: 'stripes-acq-components.acquisition_method.purchase', value: records[1].id },
+      { label: records[2].value, value: records[2].id },
     ]);
   });
 
@@ -21,5 +26,65 @@ describe('useAcqMethodsOptions', () => {
     const { result } = renderHook(() => useAcqMethodsOptions());
 
     expect(result.current).toEqual([]);
+  });
+
+  it('should exclude deprecated methods when excludeDeprecated is set', () => {
+    const { result } = renderHook(() => useAcqMethodsOptions(records, { excludeDeprecated: true }));
+
+    expect(result.current).toEqual([
+      { label: records[0].value, value: records[0].id },
+      { label: 'stripes-acq-components.acquisition_method.purchase', value: records[1].id },
+    ]);
+  });
+
+  it('should keep a deprecated method that matches the selected value', () => {
+    const { result } = renderHook(() => useAcqMethodsOptions(records, {
+      excludeDeprecated: true,
+      selectedValue: '003',
+    }));
+
+    expect(result.current).toEqual([
+      { label: records[0].value, value: records[0].id },
+      { label: 'stripes-acq-components.acquisition_method.purchase', value: records[1].id },
+      { label: records[2].value, value: records[2].id },
+    ]);
+  });
+
+  it('should suffix deprecated methods when withDeprecatedSuffix is set', () => {
+    const { result } = renderHook(() => useAcqMethodsOptions(records, { withDeprecatedSuffix: true }));
+
+    expect(result.current).toEqual([
+      { label: records[0].value, value: records[0].id },
+      { label: 'stripes-acq-components.acquisition_method.purchase', value: records[1].id },
+      { label: 'stripes-acq-components.acquisition_method.deprecatedSuffix', value: records[2].id },
+    ]);
+  });
+});
+
+describe('getAcqMethodLabel', () => {
+  const intl = { formatMessage: ({ id }) => id };
+
+  it('should return the raw value for a method without a localization key', () => {
+    expect(getAcqMethodLabel({ value: 'Test method' }, { intl })).toBe('Test method');
+  });
+
+  it('should return the localized label for a known acq method', () => {
+    expect(getAcqMethodLabel({ value: 'Purchase' }, { intl }))
+      .toBe('stripes-acq-components.acquisition_method.purchase');
+  });
+
+  it('should not suffix an active method even when withDeprecatedSuffix is set', () => {
+    expect(getAcqMethodLabel({ value: 'Test method', deprecated: false }, { intl, withDeprecatedSuffix: true }))
+      .toBe('Test method');
+  });
+
+  it('should suffix a deprecated method when withDeprecatedSuffix is set', () => {
+    expect(getAcqMethodLabel({ value: 'Test method', deprecated: true }, { intl, withDeprecatedSuffix: true }))
+      .toBe('stripes-acq-components.acquisition_method.deprecatedSuffix');
+  });
+
+  it('should not suffix a deprecated method when withDeprecatedSuffix is not set', () => {
+    expect(getAcqMethodLabel({ value: 'Test method', deprecated: true }, { intl }))
+      .toBe('Test method');
   });
 });

--- a/translations/stripes-acq-components/en.json
+++ b/translations/stripes-acq-components/en.json
@@ -244,6 +244,7 @@
   "acquisition_method.approvalPlan": "Approval plan",
   "acquisition_method.dda": "Demand driven acquisitions (DDA)",
   "acquisition_method.depository": "Depository",
+  "acquisition_method.deprecatedSuffix": "{name} (deprecated)",
   "acquisition_method.eba": "Evidence based acquisitions (EBA)",
   "acquisition_method.exchange": "Exchange",
   "acquisition_method.free": "Free",


### PR DESCRIPTION
[UISACQCOMP-301](https://folio-org.atlassian.net/browse/UISACQCOMP-301)

## Purpose
Part of the Acquisition Method deprecation feature ([UIOR-1157](https://folio-org.atlassian.net/browse/UIOR-1157)). An Acquisitions admin can flag an acquisition method as `deprecated`: deprecated methods must not be offered on new/edited PO lines or order templates, but must stay visible on existing records and searchable in filters, suffixed `(deprecated)`.


## Approach
- `useAcqMethodsOptions` now accepts new parameters (`{ excludeDeprecated = false, selectedValue, withDeprecatedSuffix = false }`). The default is unchanged behavior.
  - `excludeDeprecated` drops deprecated methods but still keeps the existing selection.
  - `withDeprecatedSuffix` appends the localised `(deprecated)` suffix to deprecated methods' labels.
- New `getAcqMethodLabel(record, { intl, withDeprecatedSuffix })` returns the localised label, suffixed only when the method is deprecated and the suffix is requested. This will be reused by `ui-orders`' PO-line view.


## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.