### PR TITLE
UISACQCOMP-304 Do not trigger refetch after search index changed in `FindRecordsModal`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Update CQL Builder to support new indices. Refs UISACQCOMP-300.
 * Unable to print pending order with po line when CO enabled. Refs UISACQCOMP-302.
+* Do not trigger refetch after search index changed in `FindRecordsModal`. Refs UISACQCOMP-304.
 
 ## [7.1.0](https://github.com/folio-org/stripes-acq-components/tree/v7.1.0) (2026-04-15)
 [Full Changelog](https://github.com/folio-org/stripes-acq-components/compare/v7.0.5...v7.1.0)

--- a/lib/FindRecords/FindRecords.test.js
+++ b/lib/FindRecords/FindRecords.test.js
@@ -3,13 +3,20 @@ import noop from 'lodash/noop';
 import { BrowserRouter as Router } from 'react-router-dom';
 
 import {
+  act,
   render,
   screen,
 } from '@folio/jest-config-stripes/testing-library/react';
 import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
+import { SearchField } from '@folio/stripes/components';
 
 import { mockOffsetSize } from '../../test/jest/helpers/mockOffsetSize';
 import { FindRecords } from './FindRecords';
+
+jest.mock('@folio/stripes/components', () => ({
+  ...jest.requireActual('@folio/stripes/components'),
+  SearchField: jest.fn(() => 'SearchField'),
+}));
 
 const renderComponent = ({
   getRecordLabel,
@@ -125,6 +132,61 @@ describe('FindRecords', () => {
       renderComponent({ trigerless: true });
 
       expect(screen.getByText('modal label')).toBeInTheDocument();
+    });
+  });
+
+  describe('search index selection', () => {
+    const getLatestSearchFieldProps = () => SearchField.mock.calls[SearchField.mock.calls.length - 1][0];
+    const submitSearchEvent = { preventDefault: noop, stopPropagation: noop };
+
+    it('should not trigger a refetch when only the search index is changed', async () => {
+      const refreshRecords = jest.fn();
+
+      renderComponent({ isLoading: false, refreshRecords });
+
+      await userEvent.click(screen.getByText('open modal'));
+
+      refreshRecords.mockClear();
+
+      act(() => getLatestSearchFieldProps().onChangeIndex({ target: { value: 'title' } }));
+
+      expect(refreshRecords).not.toHaveBeenCalled();
+    });
+
+    it('should trigger a refetch with the new index when search is applied', async () => {
+      const refreshRecords = jest.fn();
+
+      renderComponent({ isLoading: false, refreshRecords });
+
+      await userEvent.click(screen.getByText('open modal'));
+
+      refreshRecords.mockClear();
+
+      act(() => getLatestSearchFieldProps().onChangeIndex({ target: { value: 'title' } }));
+      act(() => getLatestSearchFieldProps().onChange({ target: { value: 'test' } }));
+      act(() => getLatestSearchFieldProps().onSubmitSearch(submitSearchEvent));
+
+      expect(refreshRecords).toHaveBeenCalledWith(expect.objectContaining({
+        query: 'test',
+        qindex: 'title',
+      }));
+    });
+
+    it('should not trigger a refetch when applying the same search again', async () => {
+      const refreshRecords = jest.fn();
+
+      renderComponent({ isLoading: false, refreshRecords });
+
+      await userEvent.click(screen.getByText('open modal'));
+
+      act(() => getLatestSearchFieldProps().onChange({ target: { value: 'test' } }));
+      act(() => getLatestSearchFieldProps().onSubmitSearch(submitSearchEvent));
+
+      refreshRecords.mockClear();
+
+      act(() => getLatestSearchFieldProps().onSubmitSearch(submitSearchEvent));
+
+      expect(refreshRecords).not.toHaveBeenCalled();
     });
   });
 });

--- a/lib/FindRecords/FindRecordsModal.js
+++ b/lib/FindRecords/FindRecordsModal.js
@@ -1,8 +1,10 @@
+import isEqual from 'lodash/isEqual';
 import noop from 'lodash/noop';
 import pickBy from 'lodash/pickBy';
 import PropTypes from 'prop-types';
 import {
   createRef,
+  useCallback,
   useEffect,
 } from 'react';
 import {
@@ -25,6 +27,8 @@ import {
   PrevNextPagination,
   ResetButton,
   ResultsPane,
+  SEARCH_INDEX_PARAMETER,
+  SEARCH_PARAMETER,
   SingleSearchForm,
   useFilters,
   useFiltersToogle,
@@ -91,17 +95,38 @@ export const FindRecordsModal = ({
     filters,
     searchQuery,
     applyFilters,
-    applySearch,
     changeSearch,
     resetFilters,
-    changeSearchIndex,
     searchIndex,
+    setSearchIndex,
+    setFilters,
   } = useFilters(resetData, initialFilters);
   const [
     sortingField,
     sortingDirection,
     changeSorting,
   ] = useSorting(resetData, sortableColumns);
+
+  // Only update the local `searchIndex` state when the user picks a new index.
+  // The index is merged into `filters` (which triggers a refetch) only when the
+  // user explicitly applies the search, so switching the index alone doesn't refetch.
+  // This is to avoid unnecessary refetch when the user is just browsing through the indexes.
+  const changeSearchIndex = useCallback((e) => {
+    setSearchIndex(e.target.value);
+  }, [setSearchIndex]);
+
+  const applySearch = useCallback(() => {
+    const newFilters = {
+      ...filters,
+      [SEARCH_PARAMETER]: searchQuery,
+      [SEARCH_INDEX_PARAMETER]: searchIndex,
+    };
+
+    if (isEqual(newFilters, filters)) return;
+
+    setFilters(newFilters);
+    resetData();
+  }, [filters, setFilters, searchQuery, searchIndex, resetData]);
 
   useEffect(() => {
     refreshRecords({


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://folio-org.atlassian.net/browse/UISACQCOMP-304

Selecting a new search index should not trigger a search.

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

`useFilters`'s `changeSearchIndex` previously wrote the new index straight into `filters` on every change, which triggered `refreshRecords` via the effect watching `filters`. Since `useFilters` is shared by many consumers, it was left untouched.

Instead, `FindRecordsModal` now overrides the search-related handlers locally:
- `changeSearchIndex` only updates the local `searchIndex` state (via `setSearchIndex`) — no longer touches `filters`, so selecting a new index no longer triggers a refetch.
- `applySearch` is redefined to build the candidate `filters` object (merging `searchQuery` and `searchIndex` into the current `filters`) and only calls `setFilters`/`resetData()` — which triggers the refetch — if the merged object actually differs (deep-compared with `isEqual`) from the current `filters`. This also prevents a redundant refetch when the user re-applies the same query/index.

The search is now only executed when the user explicitly clicks "Search" (or submits the form), matching the expected behavior.

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.
